### PR TITLE
feat: 신고 작성하기 API 기능 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,9 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/shinhanDS5gi/memento/common/exception/ReportException.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception/ReportException.java
@@ -1,0 +1,20 @@
+package com.shinhanDS5gi.memento.common.exception;
+
+import com.shinhanDS5gi.memento.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class ReportException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public ReportException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public ReportException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/common/exception_handler/ReportExceptionControllerAdvice.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception_handler/ReportExceptionControllerAdvice.java
@@ -1,0 +1,22 @@
+package com.shinhanDS5gi.memento.common.exception_handler;
+
+import com.shinhanDS5gi.memento.common.exception.ReportException;
+import com.shinhanDS5gi.memento.common.response.BaseErrorResponse;
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class ReportExceptionControllerAdvice {
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(ReportException.class)
+    public BaseErrorResponse handle_ReportException(ReportException e) {
+        log.error("[handle_ReportException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -14,9 +14,17 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * Token 관련 code : 3000 대
      */
-    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다."),
 
+    /**
+     * Member 관련 4000대
+     */
+    CANNOT_FOUND_MEMBER(4000,HttpStatus.OK.value(),"해당 사용자를 찾을 수 없습니다."),
 
+    /**
+     * Report 관련 8000대
+     */
+    CANNOT_FOUND_REPORT(8000, HttpStatus.NOT_FOUND.value(), "해당 ID의 신고 내역을 찾을 수 없습니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
@@ -1,0 +1,27 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+import com.shinhanDS5gi.memento.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final ReportService reportService;
+
+    @PostMapping("/reports")
+    public BaseResponse<Void> createReport(@RequestBody CreateReportRequest requestDto) {
+        Long currentMemberId = 1L;
+        reportService.createReport(currentMemberId, requestDto);
+        return new BaseResponse<>(SUCCESS, null);
+    }
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/CreateReportRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/CreateReportRequest.java
@@ -1,0 +1,32 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.report.Report;
+import com.shinhanDS5gi.memento.domain.report.ReportType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+/* 신고 관련 RequestDTO */
+public class CreateReportRequest {
+
+    @NotNull(message = "신고 유형은 필수입니다.")
+    private ReportType reportType;
+
+    @NotNull(message = "신고 대상(멘토스) ID는 필수입니다.")
+    private Long mentosSeq;
+
+    public Report toEntity(Member member, Mentos mentos) {
+        return new Report(
+                null, // 자동 생성
+                this.reportType,
+                BaseStatus.ACTIVE,
+                member,
+                mentos
+        );
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MentosRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MentosRepository.java
@@ -1,0 +1,7 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentosRepository extends JpaRepository<Mentos, Long> {
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.report.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
@@ -1,0 +1,10 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+
+public interface ReportService {
+
+    /* 신규 신고 생성 */
+    void createReport(Long memberSeq, CreateReportRequest requestDto);
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -1,0 +1,38 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.common.exception.ReportException;
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.report.Report;
+import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+import com.shinhanDS5gi.memento.repository.MemberRepository;
+import com.shinhanDS5gi.memento.repository.MentosRepository;
+import com.shinhanDS5gi.memento.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_REPORT;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportServiceImpl implements ReportService {
+
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+    private final MentosRepository mentosRepository;
+
+    @Override
+    @Transactional
+    public void createReport(Long memberSeq, CreateReportRequest requestDto) {
+        Member reporter = memberRepository.findById(memberSeq).orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
+        Mentos reportedMentos = mentosRepository.findById(requestDto.getMentosSeq())
+                .orElseThrow(() -> new ReportException(CANNOT_FOUND_REPORT));
+        Report report = requestDto.toEntity(reporter, reportedMentos);
+        reportRepository.save(report);
+    }
+
+}


### PR DESCRIPTION
## 요약 (Summary)
- [x] 작업 내용 요약
- 멘토스(멘토링)에 대한 멘티의 진행 중, 진행 후 시점에 필요 시 신고하기 기능 추가
- Restful한 설계로 API 백엔드 작업 구현
- 신고와 관련된 예외 처리, 구조 설계

## 🔑 변경 사항 (Key Changes)
- Report 관련 Controller, Service, ServiceImpl, Repository (구조) 생성 및 예외 처리 파일 (ReportException, ReportExceptionControllerAdvice) 생성 등
- 관리자 (admin) 라는 단어를 Spring Security가 자동 인식하여 build.gradle에 위치한 관련 dependency 임의 주석 처리
- 이외 기존 코드 변경사항 없음

## 📝 리뷰 요구사항 (To Reviewers)
- 먼저 테스트를 위해 더미 데이터를 생성해주세요.
<멤버 테이블>
INSERT INTO member (
member_seq, member_id, member_pwd, member_name, member_phone_number,
member_type, member_birth_date, status,
created_at, modified_at
) VALUES (
1,
'testUser01',
'encodedPassword123!',
'홍길동',
'010-1234-5678',
'MENTO',
'1990-01-01',
'ACTIVE',
NOW(), -- created_at
NOW() -- modified_at
);
<카테고리 테이블>
INSERT INTO category (
category_seq, category_name, category_description, created_at, modified_at
) VALUES (
1,
'백엔드 개발',
'백엔드 개발 카테고리입니다',
NOW(),
NOW()
);

<멘토스 테이블>
INSERT INTO mentos (
mentos_seq, mentos_title, mentos_content, price, mentos_image,
mentos_postcode, mentos_roadaddress, mentos_bname, mentos_detail,
keyword_one, keyword_two, keyword_three, status,
member_seq, category_seq,
created_at, modified_at
) VALUES (
2,
'Java 백엔드 멘토링',
'스프링 기반 백엔드 개발 경험을 공유하는 멘토링입니다.',
50000,
'mentos_sample.png',
'06236',
'서울특별시 강남구 테헤란로 123',
'삼성동',
'XX빌딩 5층',
'Java',
'Spring',
'JPA',
'ACTIVE',
1, -- member_seq FK
1, -- category_seq FK (위에서 추가한 카테고리)
NOW(),
NOW()
);

## 확인 방법 
<img width="1915" height="1085" alt="image" src="https://github.com/user-attachments/assets/0cddabf4-e9d7-4735-8db8-8d9676ddae9f" />

세 가지 테이블에 각각 순서대로 더미 데이터 생성 후,
Postman을 열고 POST 방식 선택 후 'http://localhost:9999/admin/reports' 주소 추가.
Body - raw 클릭 -> JSON 방식 선택.
{
"reportType": "GAMBLING",
"mentosSeq": 2
}

라는 임의의 데이터 입력.

200 OK 뜨는 것 확인 후 mysql DB에 select * from report 조회.
형식에 맞게 데이터가 들어와있는지 확인 후 테스트 종료.