### PR TITLE
feat : 특정 신고 내역 상세 조회하기 API 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,9 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/shinhanDS5gi/memento/common/exception/ReportException.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception/ReportException.java
@@ -1,0 +1,20 @@
+package com.shinhanDS5gi.memento.common.exception;
+
+import com.shinhanDS5gi.memento.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class ReportException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public ReportException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public ReportException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/common/exception_handler/ReportExceptionControllerAdvice.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception_handler/ReportExceptionControllerAdvice.java
@@ -1,0 +1,22 @@
+package com.shinhanDS5gi.memento.common.exception_handler;
+
+import com.shinhanDS5gi.memento.common.exception.ReportException;
+import com.shinhanDS5gi.memento.common.response.BaseErrorResponse;
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class ReportExceptionControllerAdvice {
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(ReportException.class)
+    public BaseErrorResponse handle_ReportException(ReportException e) {
+        log.error("[handle_ReportException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -14,9 +14,17 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * Token 관련 code : 3000 대
      */
-    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다."),
 
+    /**
+     * Member 관련 4000대
+     */
+    CANNOT_FOUND_MEMBER(4000,HttpStatus.OK.value(),"해당 사용자를 찾을 수 없습니다."),
 
+    /**
+     * Report 관련 8000대
+     */
+    CANNOT_FOUND_REPORT(8000, HttpStatus.NOT_FOUND.value(), "해당 ID의 신고 내역을 찾을 수 없습니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
@@ -2,10 +2,13 @@ package com.shinhanDS5gi.memento.controller;
 
 import com.shinhanDS5gi.memento.common.response.BaseResponse;
 import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+import com.shinhanDS5gi.memento.dto.SelectReportResponse;
 import com.shinhanDS5gi.memento.service.ReportService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
 
@@ -22,6 +25,13 @@ public class AdminController {
         Long currentMemberId = 1L;
         reportService.createReport(currentMemberId, requestDto);
         return new BaseResponse<>(SUCCESS, null);
+    }
+
+    /* 모든 신고 내역 조회 */
+    @GetMapping("/reports")
+    public BaseResponse<List<SelectReportResponse>> getAllReports() {
+        List<SelectReportResponse> reportAll = reportService.findAllReports();
+        return new BaseResponse<>(reportAll);
     }
 
 }

--- a/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
@@ -34,4 +34,11 @@ public class AdminController {
         return new BaseResponse<>(reportAll);
     }
 
+    /* 특정 신고 내역 상세 조회 */
+    @GetMapping("/reports/{reportSeq}")
+    public BaseResponse<SelectReportResponse> getReportById(@PathVariable("reportSeq") Long reportSeq) {
+        SelectReportResponse report = reportService.findReportById(reportSeq);
+        return new BaseResponse<>(report);
+    }
+
 }

--- a/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
@@ -1,0 +1,27 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+import com.shinhanDS5gi.memento.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final ReportService reportService;
+
+    @PostMapping("/reports")
+    public BaseResponse<Void> createReport(@RequestBody CreateReportRequest requestDto) {
+        Long currentMemberId = 1L;
+        reportService.createReport(currentMemberId, requestDto);
+        return new BaseResponse<>(SUCCESS, null);
+    }
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/CreateReportRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/CreateReportRequest.java
@@ -1,0 +1,32 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.report.Report;
+import com.shinhanDS5gi.memento.domain.report.ReportType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+/* 신고 관련 RequestDTO */
+public class CreateReportRequest {
+
+    @NotNull(message = "신고 유형은 필수입니다.")
+    private ReportType reportType;
+
+    @NotNull(message = "신고 대상(멘토스) ID는 필수입니다.")
+    private Long mentosSeq;
+
+    public Report toEntity(Member member, Mentos mentos) {
+        return new Report(
+                null, // 자동 생성
+                this.reportType,
+                BaseStatus.ACTIVE,
+                member,
+                mentos
+        );
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/SelectReportResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/SelectReportResponse.java
@@ -1,0 +1,26 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.report.Report;
+import com.shinhanDS5gi.memento.domain.report.ReportType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SelectReportResponse {
+
+    private final Long reportSeq;
+    private final ReportType reportType;
+    private final String reporterName; // 신고자 이름
+    private final Long reportedMentosSeq;  // 신고된 멘토스 시퀀스
+    private final LocalDateTime createdAt; // 신고 생성 시간
+
+
+    public SelectReportResponse(Report report) {
+        this.reportSeq = report.getReportSeq();
+        this.reportType = report.getReportType();
+        this.reporterName = report.getMember().getMemberName();
+        this.reportedMentosSeq = report.getMentos().getMentosSeq();
+        this.createdAt = report.getCreatedAt();
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MentosRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MentosRepository.java
@@ -1,0 +1,7 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentosRepository extends JpaRepository<Mentos, Long> {
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
@@ -3,7 +3,10 @@ package com.shinhanDS5gi.memento.repository;
 import com.shinhanDS5gi.memento.domain.report.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
@@ -11,4 +14,8 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
         +1 문제를 해결하기 위해 fetch join을 사용하여 연관된 Member, Mentos 엔티티를 함께 조회 */
     @Query("SELECT r FROM Report r JOIN FETCH r.member m JOIN FETCH r.mentos mt")
     List<Report> findAllWithMemberAndMentos();
+
+    /* reportSeq를 기준으로 특정 신고 내역 조회 */
+    @Query("SELECT r FROM Report r JOIN FETCH r.member m JOIN FETCH r.mentos mt WHERE r.reportSeq = :reportSeq")
+    Optional<Report> findByIdWithMemberAndMentos(@Param("reportSeq") Long reportSeq);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-    /* 모든 신고 내역을 조회
+    /* 모든 신고 내역을 조회하는 메서드
         +1 문제를 해결하기 위해 fetch join을 사용하여 연관된 Member, Mentos 엔티티를 함께 조회 */
     @Query("SELECT r FROM Report r JOIN FETCH r.member m JOIN FETCH r.mentos mt")
     List<Report> findAllWithMemberAndMentos();

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
@@ -2,7 +2,13 @@ package com.shinhanDS5gi.memento.repository;
 
 import com.shinhanDS5gi.memento.domain.report.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
+    /* 모든 신고 내역을 조회
+        +1 문제를 해결하기 위해 fetch join을 사용하여 연관된 Member, Mentos 엔티티를 함께 조회 */
+    @Query("SELECT r FROM Report r JOIN FETCH r.member m JOIN FETCH r.mentos mt")
+    List<Report> findAllWithMemberAndMentos();
 }

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.report.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
@@ -12,4 +12,7 @@ public interface ReportService {
 
     /* 모든 신고 내역 조회 */
     List<SelectReportResponse> findAllReports();
+
+    /* 특정 신고 상세 내역 조회 */
+    SelectReportResponse findReportById(Long reportSeq);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
@@ -1,10 +1,15 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+import com.shinhanDS5gi.memento.dto.SelectReportResponse;
+
+import java.util.List;
 
 public interface ReportService {
 
     /* 신규 신고 생성 */
     void createReport(Long memberSeq, CreateReportRequest requestDto);
 
+    /* 모든 신고 내역 조회 */
+    List<SelectReportResponse> findAllReports();
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
@@ -1,0 +1,10 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+
+public interface ReportService {
+
+    /* 신규 신고 생성 */
+    void createReport(Long memberSeq, CreateReportRequest requestDto);
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -47,4 +47,10 @@ public class ReportServiceImpl implements ReportService {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public SelectReportResponse findReportById(Long reportSeq) {
+        return reportRepository.findByIdWithMemberAndMentos(reportSeq)
+                .map(SelectReportResponse::new)
+                .orElse(null);
+    }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -1,0 +1,38 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.common.exception.ReportException;
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.report.Report;
+import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+import com.shinhanDS5gi.memento.repository.MemberRepository;
+import com.shinhanDS5gi.memento.repository.MentosRepository;
+import com.shinhanDS5gi.memento.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_REPORT;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportServiceImpl implements ReportService {
+
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+    private final MentosRepository mentosRepository;
+
+    @Override
+    @Transactional
+    public void createReport(Long memberSeq, CreateReportRequest requestDto) {
+        Member reporter = memberRepository.findById(memberSeq).orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
+        Mentos reportedMentos = mentosRepository.findById(requestDto.getMentosSeq())
+                .orElseThrow(() -> new ReportException(CANNOT_FOUND_REPORT));
+        Report report = requestDto.toEntity(reporter, reportedMentos);
+        reportRepository.save(report);
+    }
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -6,12 +6,16 @@ import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.report.Report;
 import com.shinhanDS5gi.memento.dto.CreateReportRequest;
+import com.shinhanDS5gi.memento.dto.SelectReportResponse;
 import com.shinhanDS5gi.memento.repository.MemberRepository;
 import com.shinhanDS5gi.memento.repository.MentosRepository;
 import com.shinhanDS5gi.memento.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_REPORT;
@@ -33,6 +37,14 @@ public class ReportServiceImpl implements ReportService {
                 .orElseThrow(() -> new ReportException(CANNOT_FOUND_REPORT));
         Report report = requestDto.toEntity(reporter, reportedMentos);
         reportRepository.save(report);
+    }
+
+    @Override
+    public List<SelectReportResponse> findAllReports() {
+        List<Report> reports = reportRepository.findAllWithMemberAndMentos();
+        return reports.stream()
+                .map(SelectReportResponse::new)
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
## 요약 (Summary)
- Report (신고 관련) Controller, Service, ServiceImpl, Repository 수정
- Report 테이블 조회를 위한 DTO 생성 (SelectReportResponse)

## 🔑 변경 사항 (Key Changes)

- 활성화된 신고 내역 중 특정 신고 내역 상세 조회를 위한 메서드 추가

## 📝 리뷰 요구사항 (To Reviewers)

- Report 테이블의 데이터 중 원하는 데이터의 reportSeq를 선택해 조회해야 함.

## 확인 방법 
DB에 더미 데이터를 추가해준다.

INSERT INTO Report (
report_seq,
member_seq,
mentos_seq,
report_type,
status,
created_at,
modified_at
) VALUES (
null,
1, -- member_seq
2, -- mentos_seq
'GAMBLING', -- report_type
'ACTIVE', -- status
'2025-08-22 12:51:18.844447', -- created_at
'2025-08-22 12:51:18.844447' -- modified_at
);

이후 Postman을 실행하고 Get 방식으로 아래와 같은 경로 설정 및 파라미터를 추가해 send 한다.
-> 'http://localhost:9999/admin/reports/1'
<img width="1912" height="1132" alt="image" src="https://github.com/user-attachments/assets/8264cb5e-345f-4f8e-9e5f-d3c174cb78cc" />

이미지와 같이 요청에 성공하고 result 값이 보인다면 테스트 완료.