### PR TITLE
feat: 멘토 첫 로그인 시 멘토 프로필 추가 입력 및 생성 API 구현 완료

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -14,9 +14,22 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * Token 관련 code : 3000 대
      */
-    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다."),
 
+    /**
+     * Member 관련 4000대
+     */
+    CANNOT_FOUND_MEMBER(4000,HttpStatus.OK.value(),"해당 사용자를 찾을 수 없습니다."),
 
+    /**
+     * Report 관련 8000대
+     */
+    CANNOT_FOUND_REPORT(8000, HttpStatus.NOT_FOUND.value(), "해당 ID의 신고 내역을 찾을 수 없습니다."),
+
+    /**
+     * MentoProfile 관련 9000대
+     */
+    ALREADY_EXISTS_MENTO_PROFILE(9000, HttpStatus.BAD_REQUEST.value(), "이미 멘토 프로필이 존재합니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
@@ -1,0 +1,31 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.dto.CreateMentoProfileRequest;
+import com.shinhanDS5gi.memento.service.MentoProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mento")
+public class MentoController {
+
+    private final MentoProfileService mentoProfileService;
+
+    @PostMapping("/mento-profiles")
+    public BaseResponse<Void> createMentoProfile(@RequestBody CreateMentoProfileRequest requestDto) {
+
+        Long currentMemberId = 1L; // 임시 사용자 ID
+        mentoProfileService.createMentoProfile(currentMemberId, requestDto);
+
+        return new BaseResponse<>(SUCCESS, null);
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/CreateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/CreateMentoProfileRequest.java
@@ -1,0 +1,30 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.MentoProfile;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+/* 멘토 프로필 관련 RequestDTO */
+public class CreateMentoProfileRequest {
+
+    @NotBlank(message = "멘토 소개 내용은 필수입니다.")
+    private String mentoProfileContent;
+
+    @NotBlank(message = "프로필 이미지는 필수입니다.")
+    private String mentoProfileImage;
+
+    public MentoProfile toEntity(Member member) {
+        return new MentoProfile(
+                null,
+                this.mentoProfileContent,
+                this.mentoProfileImage,
+                BaseStatus.ACTIVE,
+                member
+        );
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MentoProfileRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MentoProfileRepository.java
@@ -1,0 +1,10 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.MentoProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoProfileRepository extends JpaRepository<MentoProfile, Long> {
+
+    /* memberSeq를 기준으로 멘토 프로필이 존재하는지 확인 */
+    boolean existsByMember_MemberSeq(Long memberSeq);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
@@ -1,0 +1,9 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.CreateMentoProfileRequest;
+
+public interface MentoProfileService {
+
+    /* 신규 멘토 프로필 생성 */
+    void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
@@ -1,0 +1,45 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.domain.MentoProfile;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.member.MemberType;
+import com.shinhanDS5gi.memento.dto.CreateMentoProfileRequest;
+import com.shinhanDS5gi.memento.repository.MemberRepository;
+import com.shinhanDS5gi.memento.repository.MentoProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MentoProfileServiceImpl implements MentoProfileService {
+
+    private final MentoProfileRepository mentoProfileRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto) {
+
+        /* 회원 가입한 사용자인가? */
+        Member member = memberRepository.findById(memberSeq)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+
+        /* 멘토인가? */
+        if (member.getMemberType() != MemberType.MENTO) {
+            throw new MemberException(FAILURE, "멘토 회원만 프로필을 생성할 수 있습니다.");
+        }
+
+        /* 이미 멘토프로필 생성하진 않았는가? */
+        if (mentoProfileRepository.existsByMember_MemberSeq(memberSeq)) {
+            throw new MemberException(ALREADY_EXISTS_MENTO_PROFILE);
+        }
+
+        MentoProfile mentoProfile = requestDto.toEntity(member);
+        mentoProfileRepository.save(mentoProfile);
+    }
+}


### PR DESCRIPTION
## 요약 (Summary)
- 유저가 멘토 타입으로 회원 가입 후 첫 로그인 시 멘토 프로필 정보를 추가로 입력받게 되는데 이에 대한 메서드 구현 완료.
- 프로필 이미지와 멘토 소개글을 입력받아 mento_profile이라는 테이블에 저장하게 됨. 

## 🔑 변경 사항 (Key Changes)

- Mento_profile 테이블과 관련된 Controller, Service, ServiceImpl, Repository, DTO를 생성함.
- BaseExceptionResponseStatus 파일에 MentoProfile 관련 에러 정보 추가함.
- 이외 공통 코드 변경 사항 없음.

## 📝 리뷰 요구사항 (To Reviewers)

- 멤버 타입이 'MENTO'인 임의의 member 데이터를 Member 테이블에 입력해야 합니다.
INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at)
VALUES (1, 'mento_user', 'password123', '김멘토', '010-1234-5678', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW());

## 확인 방법 
member 더미 데이터가 Member 테이블에 잘 들어갔는지 먼저 확인합니다.
postman에 POST 방식으로 Body - raw 클릭 후 JSON 설정 후  'http://localhost:9999/mento/mento-profiles'을 입력해 Send합니다.

![멘토프로필 1](https://github.com/user-attachments/assets/f86037e9-e616-4400-baa5-d109b684c61d)
위의 이미지와 같이 요청에 성공했다는 메시지가 뜨는지 확인합니다.

![멘토 프로필 2](https://github.com/user-attachments/assets/c9bb4268-33e4-4b41-8529-1b859f58e177)
한 번 더 send하게 되면 이미 멘토 프로필이 생성된 member이기 때문에 위의 이미지와 같이 이미 멘토 프로필이 존재한다는 메시지가 뜨는지 확인합니다.

![멘토 프로필 3](https://github.com/user-attachments/assets/552f1e89-68ad-4a99-999d-301d33bed44f)
DB에서 위의 이미지와 같이 mento_profile 테이블 조회 시 알맞게 데이터가 들어와 있는지 확인 후 테스트 종료.
