### PR TITLE
feat: 멘토 자격증 추가하기 API 구현 완료

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -14,9 +14,13 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * Token 관련 code : 3000 대
      */
-    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다."),
 
-
+    /**
+     * Member 관련 4000대
+     */
+    CANNOT_FOUND_MEMBER(4000,HttpStatus.NOT_FOUND.value(),"해당 사용자를 찾을 수 없습니다."),
+    NOT_A_MENTO(4001, HttpStatus.FORBIDDEN.value(), "멘토 회원만 접근할 수 있는 기능입니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
@@ -1,0 +1,31 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.dto.CreateMentoCertificationRequest;
+import com.shinhanDS5gi.memento.service.MentoCertificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mento")
+public class MentoController {
+
+    private final MentoCertificationService mentoCertificationService;
+
+    @PostMapping("/mento-certifications")
+    public BaseResponse<Void> createMentoCertification(@RequestBody CreateMentoCertificationRequest requestDto) {
+
+        Long currentMemberId = 1L; // 임시 사용자 ID
+        mentoCertificationService.createMentoCertification(currentMemberId, requestDto);
+
+        return new BaseResponse<>(SUCCESS, null);
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/CreateMentoCertificationRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/CreateMentoCertificationRequest.java
@@ -5,7 +5,6 @@ import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/shinhanDS5gi/memento/dto/CreateMentoCertificationRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/CreateMentoCertificationRequest.java
@@ -1,0 +1,42 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.MentoCertification;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreateMentoCertificationRequest {
+
+    @Valid
+    private List<CertificationInfo> certifications;
+
+    /* 개별 자격증의 정보를 담는 내부 DTO 클래스 */
+    @Getter
+    @NoArgsConstructor
+    public static class CertificationInfo {
+
+        @NotBlank(message = "자격증 이름은 필수입니다.")
+        private String name;
+
+        @NotBlank(message = "자격증 이미지는 필수입니다.")
+        private String imageUrl;
+
+        public MentoCertification toEntity(Member member) {
+            return new MentoCertification(
+                    null,
+                    this.name,
+                    this.imageUrl,
+                    BaseStatus.ACTIVE,
+                    member
+            );
+        }
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MentoCertificationRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MentoCertificationRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.MentoCertification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoCertificationRepository extends JpaRepository<MentoCertification, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationService.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.CreateMentoCertificationRequest;
+
+public interface MentoCertificationService {
+
+    void createMentoCertification(Long memberSeq, CreateMentoCertificationRequest requestDto);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationServiceImpl.java
@@ -1,0 +1,47 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.domain.MentoCertification;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.member.MemberType;
+import com.shinhanDS5gi.memento.dto.CreateMentoCertificationRequest;
+import com.shinhanDS5gi.memento.repository.MemberRepository;
+import com.shinhanDS5gi.memento.repository.MentoCertificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.NOT_A_MENTO;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MentoCertificationServiceImpl implements MentoCertificationService {
+
+    private final MemberRepository memberRepository;
+    private final MentoCertificationRepository mentoCertificationRepository;
+
+    @Override
+    @Transactional
+    public void createMentoCertification(Long memberSeq, CreateMentoCertificationRequest requestDto) {
+        // 1. 사용자 조회
+        Member member = memberRepository.findById(memberSeq)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+
+        // 2. 멘토 타입인지 검증
+        if (member.getMemberType() != MemberType.MENTO) {
+            throw new MemberException(NOT_A_MENTO);
+        }
+
+        // 3. DTO 리스트를 엔티티 리스트로 변환
+        List<MentoCertification> certifications = requestDto.getCertifications().stream()
+                .map(certInfo -> certInfo.toEntity(member))
+                .collect(Collectors.toList());
+
+        mentoCertificationRepository.saveAll(certifications);
+    }
+}


### PR DESCRIPTION
## 요약 (Summary)
- 멘토의 인증 수단 중 하나인 자격증 추가하기에 대한 기능 API 구현 완료
- 파일 형태의 데이터를 배열 단위로 한 번에 여러 개 추가 가능함.
- 업로드한 파일에 대해 DB에 저장하는 기능이지만, 업로드한 자격증을 인증하는 기능은 아님. 

## 🔑 변경 사항 (Key Changes)

- Mento-Certification 관련 Controller, Service, ServiceImpl, CreateDTO, Repository 생성.
- 완료, 에러 처리를 위해 공통 enum 추가. (BaseExceptionResponseStatus -> 'NOT_A_MENTO' 추가

## 📝 리뷰 요구사항 (To Reviewers)

- 자격증을 추가하기 위해서는 먼저 'MENTO' 유저 타입을 가진 멤버 데이터가 있어야 함. -> 더미 데이터 실행 필수
-- member 테이블에 member_seq = 1인 MENTO 타입 사용자 추가 (이미 있다면 실행할 필요 없음)

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at)
VALUES (1, 'mento_user', 'password123', '김멘토', '010-1234-5678', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW());

<img width="2100" height="1013" alt="image" src="https://github.com/user-attachments/assets/521769f3-cc5d-4165-8df6-756d1d0ad1d1" />

## 확인 방법 
- 컨트롤러(MentoController)에 임의의 member_seq 값이 1로 설정되어 있는지 확인.
- postman을 열고 새로운 request 오픈. POST 방식으로 'http://localhost:9999/mento/mento-certifications' 입력
- Body - raw - JSON 방식 채택 후, 
 
{
  "certifications": [
    {
      "name": "정보처리기사",
      "imageUrl": "https://example.com/certs/cert1.jpg"
    },
    {
      "name": "SQLD",
      "imageUrl": "https://example.com/certs/cert2.png"
    },
    {
      "name": "AWS Certified Solutions Architect",
      "imageUrl": "https://example.com/certs/cert3.pdf"
    }
  ]
}

JSON 명령어 등록 -> Send
- 요청에 성공했다는 (200 OK) 상태가 뜨면 DB에서 Mento_certification 테이블에 제대로 들어갔는지 확인.
- 여러 번 send, 내용 변경 후 send 등 다양한 방식으로 등록해도 잘 들어가는 것 확인 가능. (개수 제한 두지 않음.) -> 테스트 종료