### PR TITLE
feat: 회원가입 멘토 API 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -44,6 +44,9 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //비밀번호 해시
+    implementation 'org.springframework.security:spring-security-crypto'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -14,8 +14,11 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     /**
      * Token 관련 code : 3000 대
      */
-    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다.");
-
+    INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다."),
+    /**
+     * Auth 관련 5000대
+     */
+    CANNOT_SIGNUP(5000,HttpStatus.BAD_REQUEST.value(),"회원가입에 실패하셨습니다.");
 
 
     private final int code;

--- a/src/main/java/com/shinhanDS5gi/memento/config/PasswordConfig.java
+++ b/src/main/java/com/shinhanDS5gi/memento/config/PasswordConfig.java
@@ -1,0 +1,13 @@
+package com.shinhanDS5gi.memento.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PasswordConfig {
+    //비밀번호 해시(보완을 위해) ServiceImpl에서 @RequiredArgsConstructor로 PasswordEncoder를 주입받아 사용
+    @Bean
+    public org.springframework.security.crypto.password.PasswordEncoder passwordEncoder() {
+        return new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.dto.MentoSignupRequest;
+import com.shinhanDS5gi.memento.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final MemberService memberService;
+    //회원가입 (멘토)
+    @PostMapping("/signup/mento")
+    public BaseResponse<Void> signupMento(@RequestBody MentoSignupRequest requestDto) {
+
+        // 멘티 회원가입 서비스 호출
+        memberService.signupMento(requestDto);
+
+        // 성공 응답 리턴
+        return new BaseResponse<>(SUCCESS, null);
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/domain/member/Member.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/member/Member.java
@@ -63,22 +63,27 @@ public class Member extends BaseTime {
     @OneToMany(mappedBy = "member")
     private List<MentoCertification> mentoCertificationList  = new ArrayList<>(); //Default는 “필드 + 초기값” 세트
 
+    @Builder.Default //DB에서 NOT NULL로 적혀있기에 null로 들어가지 말라고 작성
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Payment> paymentList = new ArrayList<>();
 
+    @Builder.Default //DB에서 NOT NULL로 적혀있기에 null로 들어가지 말라고 작성
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Reservation> reservationList = new ArrayList<>();
 
+    @Builder.Default //DB에서 NOT NULL로 적혀있기에 null로 들어가지 말라고 작성
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Report> reportList = new ArrayList<>();
 
+    @Builder.Default //DB에서 NOT NULL로 적혀있기에 null로 들어가지 말라고 작성
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Mentos> mentosList = new ArrayList<>();
 
+    @Builder.Default //DB에서 NOT NULL로 적혀있기에 null로 들어가지 말라고 작성
     @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Review> reviewList = new ArrayList<>();

--- a/src/main/java/com/shinhanDS5gi/memento/domain/member/Member.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/member/Member.java
@@ -8,6 +8,8 @@ import com.shinhanDS5gi.memento.domain.payment.Payment;
 import com.shinhanDS5gi.memento.domain.report.Report;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,17 +49,19 @@ public class Member extends BaseTime {
     @Column(nullable = false)
     private LocalDate memberBirthDate;
 
+    @Builder.Default //DB에서 NOT NULL로 적혀있기에 null로 들어가지 말라고 작성
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private BaseStatus status;
+    private BaseStatus status= BaseStatus.ACTIVE; //Default는 “필드 + 초기값” 세트
 
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JsonIgnore
     private MentoProfile mentoProfile;
 
+    @Builder.Default //기본생성자여서 엔티티 생성 시에는 null 안 되는데, 빌더로 만들 때는 무시되고 null 들어가는걸 방지
     @JsonIgnore
     @OneToMany(mappedBy = "member")
-    private List<MentoCertification> mentoCertificationList  = new ArrayList<>();
+    private List<MentoCertification> mentoCertificationList  = new ArrayList<>(); //Default는 “필드 + 초기값” 세트
 
     @JsonIgnore
     @OneToMany(mappedBy = "member")

--- a/src/main/java/com/shinhanDS5gi/memento/domain/member/Member.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/member/Member.java
@@ -8,6 +8,7 @@ import com.shinhanDS5gi.memento.domain.payment.Payment;
 import com.shinhanDS5gi.memento.domain.report.Report;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder //엔티티에 저장하기 위해 넣었음
 public class Member extends BaseTime {
 
     @Id

--- a/src/main/java/com/shinhanDS5gi/memento/dto/MentoCertificationRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/MentoCertificationRequest.java
@@ -1,0 +1,20 @@
+package com.shinhanDS5gi.memento.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+//멘토 자격증받을때 이름과, 파일를 가져올 DTO
+public class MentoCertificationRequest {
+    // "certificationFile": "저축소비.pdf"
+    private String certificationFile;
+
+    // "certificationName": "자격증이름"
+    private String certificationName;
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/MentoSignupRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/MentoSignupRequest.java
@@ -1,7 +1,6 @@
 package com.shinhanDS5gi.memento.dto;
 
-import com.shinhanDS5gi.memento.domain.MentoCertification;
-import com.shinhanDS5gi.memento.domain.member.Member;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/shinhanDS5gi/memento/dto/MentoSignupRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/MentoSignupRequest.java
@@ -1,0 +1,26 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.MentoCertification;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+//회원가입 멘토 DTO
+public class MentoSignupRequest {
+    private String memberId;
+    private String memberPwd;
+    private String memberName;
+    private String memberPhoneNumber;
+    private String memberBirthDate;
+
+    private List<MentoCertificationRequest> certification; //멘토 자격증
+
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    //로그인 시 아이디 중복확인을 위해 작성
+    boolean existsByMemberId(String memberId);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MentoCertificationRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MentoCertificationRepository.java
@@ -1,0 +1,6 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.MentoCertification;
+import org.springframework.data.jpa.repository.JpaRepository;
+//멘토 자격증 저장용
+public interface MentoCertificationRepository extends JpaRepository<MentoCertification, Long> {}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.MentoSignupRequest;
+
+public interface MemberService {
+    //회원가입 멘토
+    void signupMento (MentoSignupRequest req);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
@@ -1,0 +1,71 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus;
+import com.shinhanDS5gi.memento.domain.MentoCertification;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.member.MemberType;
+import com.shinhanDS5gi.memento.dto.MentoCertificationRequest;
+import com.shinhanDS5gi.memento.dto.MentoSignupRequest;
+import com.shinhanDS5gi.memento.repository.MemberRepository;
+import com.shinhanDS5gi.memento.repository.MentoCertificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService{
+    final MemberRepository memberRepo;
+    final PasswordEncoder passwordEncoder;
+    private final MentoCertificationRepository certRepo;
+
+        @Override
+        public void signupMento(MentoSignupRequest req) {
+            // 1) 중복 아이디 체크
+            if (memberRepo.existsByMemberId(req.getMemberId())) {
+                throw new MemberException(BaseExceptionResponseStatus.CANNOT_SIGNUP);
+            }
+            // 2) 생년월일 파싱 (yyyy-MM-dd)
+            LocalDate birth = LocalDate.parse(req.getMemberBirthDate());
+
+            // 3) 엔티티에 회원 저장 (MENTO)
+            Member member = Member.builder()
+                    .memberId(req.getMemberId())
+                    .memberPwd(passwordEncoder.encode(req.getMemberPwd()))
+                    .memberName(req.getMemberName())
+                    .memberPhoneNumber(req.getMemberPhoneNumber())
+                    .memberBirthDate(birth)
+                    .memberType(MemberType.MENTO)
+                    .status(BaseStatus.ACTIVE)
+                    .build();
+            memberRepo.save(member);
+
+            // 4) 자격증 저장
+            List<MentoCertificationRequest> certReqs = req.getCertification();
+            //자격증 없으면 스킵처리 / 있으면 저장
+            if (certReqs != null && !certReqs.isEmpty()) {
+                //DTO를 엔티티로 변환해서 List에 저장
+                List<MentoCertification> entities = new ArrayList<>(certReqs.size());
+                //자격증 하나씩 처리
+                for (MentoCertificationRequest c : certReqs) {
+                    entities.add(new MentoCertification(
+                            null,     // PK 자동
+                            c.getCertificationName(),  // mentoCertificationName
+                            c.getCertificationFile(),  // mentoCertificationImage
+                            BaseStatus.ACTIVE,
+                            member
+                    ));
+                }
+                certRepo.saveAll(entities);
+            }
+        }
+
+}


### PR DESCRIPTION
## 요약 (Summary)
- [x] 작업 내용 요약
- 멘티에 대한 회원가입
- Restful한 설계로 API 백엔드 작업 구현

## 🔑 변경 사항 (Key Changes)
- signup/mento 관련 Controller, Service, ServiceImpl, Repository ,DTO(MentoSignupRequest.java) (구조) 생성
- 자격증 등록을 위해 MentoCertificationRepository 생성
- 비밀번호 해시를 위해 build.gradle, 코드 추가,PasswordConfig (구조)생성
- 예외처리를 위해 BaseExceptionResponseStatus 코드 추가
- 이외 기존 코드 변경사항 없음

## 📝 리뷰 요구사항 (To Reviewers)
POSTMAN에서
POST로` http://localhost:9999/auth/signup/mento url` 작성
<자격증 유>
```
{
  "memberId": "mento1",
  "memberPwd": "1234",
  "memberName": "김상순",
  "memberPhoneNumber": "010-9999-8888",
  "memberBirthDate": "1995-05-05",
  "certification": [
    {
      "certificationFile": "finance.pdf",
      "certificationName": "금융자격증"
    }
  ]
}
```
<자격증 무>
```
{
"memberId": "mento2",
  "memberPwd": "1234",
  "memberName": "홍길동",
  "memberPhoneNumber": "010-1234-5678",
  "memberBirthDate": "2000-01-01",
  "certificationFile": [
  
	]
}

```
각각 입력해서 자격증 유/무 둘 다 확인해주세요
그러면 DB에 저장된 걸 확인 가능합니다

## 확인 방법 
<img width="1254" height="982" alt="image" src="https://github.com/user-attachments/assets/18501a0e-a110-40b9-beeb-92c7b2388c52" />

<img width="1254" height="950" alt="image" src="https://github.com/user-attachments/assets/da5a0673-a1ab-490a-8d0d-2330efaf7163" />




이렇게 입력하면 DB에 아래처럼 member 테이블에 회원가입 된것이 확인이 가능하고 
<img width="1292" height="654" alt="image" src="https://github.com/user-attachments/assets/1a53af7b-2d79-4310-9c6d-4d3aba85efbf" />


mento_certification테이블을 확인해보면 member_seq: 1인 김상순이 자격증이 추가된걸 확인하실수 있습니다.  
<img width="1287" height="693" alt="image" src="https://github.com/user-attachments/assets/1ac4bf79-0b06-4516-8471-6f5bcd052beb" />


멘티 회원가입과 마찬가지로 비밀번호 해시 처리 되어있는지도 확인해주세요 

