### PR TITLE
feat : 멘토스 삭제하기

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -11,10 +11,18 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
      */
     SUCCESS(1000,HttpStatus.OK.value(), "요청에 성공하였습니다."),
     FAILURE(2000, HttpStatus.BAD_REQUEST.value(), "요청에 실패하였습니다."),
+
+    /**
+     * Mentos 관련 code : 2500 대
+     */
+    CANNOT_FOUND_MENTOS(2500, HttpStatus.NOT_FOUND.value(), "해당 멘토스 게시글을 찾을 수 없습니다."),
+    NO_AUTHORITY_TO_UPDATE(2501, HttpStatus.FORBIDDEN.value(), "게시글을 수정할 권한이 없습니다."),
+
     /**
      * Token 관련 code : 3000 대
      */
     INVALID_TOKEN(3000, HttpStatus.OK.value(), "유효하지 않은 토큰입니다.");
+
 
 
 

--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -17,6 +17,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
      */
     CANNOT_FOUND_MENTOS(2500, HttpStatus.NOT_FOUND.value(), "해당 멘토스 게시글을 찾을 수 없습니다."),
     NO_AUTHORITY_TO_UPDATE(2501, HttpStatus.FORBIDDEN.value(), "게시글을 수정할 권한이 없습니다."),
+    NO_AUTHORITY_TO_DELETE(2502, HttpStatus.FORBIDDEN.value(), "게시글을 삭제할 권한이 없습니다."),
 
     /**
      * Token 관련 code : 3000 대

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -1,0 +1,37 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.dto.MentosDetailResponse;
+import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
+import com.shinhanDS5gi.memento.service.MentosService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mentos")
+public class MentosController {
+
+    private final MentosService mentosService;
+
+    /* 멘토스 기존 정보 조회 */
+    @GetMapping("/{mentosSeq}")
+    public BaseResponse<MentosDetailResponse> getMentosForUpdate(@PathVariable("mentosSeq") Long mentosSeq) {
+        MentosDetailResponse mentos = mentosService.getMentosById(mentosSeq);
+        return new BaseResponse<>(SUCCESS, mentos);
+    }
+
+    /* 멘토스 게시글 수정 */
+    @PutMapping("/{mentosSeq}")
+    public BaseResponse<Void> updateMentos(@PathVariable("mentosSeq") Long mentosSeq, @RequestBody UpdateMentosRequest requestDto) {
+
+        Long currentMemberId = 2L;
+        mentosService.updateMentos(mentosSeq, currentMemberId, requestDto);
+
+        return new BaseResponse<>(SUCCESS, null);
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -29,8 +29,17 @@ public class MentosController {
     @PutMapping("/{mentosSeq}")
     public BaseResponse<Void> updateMentos(@PathVariable("mentosSeq") Long mentosSeq, @RequestBody UpdateMentosRequest requestDto) {
 
-        Long currentMemberId = 2L;
+        Long currentMemberId = 1L;
         mentosService.updateMentos(mentosSeq, currentMemberId, requestDto);
+
+        return new BaseResponse<>(SUCCESS, null);
+    }
+
+    /* 멘토스 게시글 삭제 (비활성화) */
+    @PatchMapping("/{mentosSeq}")
+    public BaseResponse<Void> inactiveMentos(@PathVariable("mentosSeq") Long mentosSeq) {
+        Long currentMemberId = 1L;
+        mentosService.inactiveMentos(mentosSeq, currentMemberId);
 
         return new BaseResponse<>(SUCCESS, null);
     }

--- a/src/main/java/com/shinhanDS5gi/memento/domain/Mentos.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/Mentos.java
@@ -9,12 +9,14 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class Mentos extends BaseTime {

--- a/src/main/java/com/shinhanDS5gi/memento/dto/MentosDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/MentosDetailResponse.java
@@ -1,0 +1,37 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import lombok.Getter;
+
+/* 멘토스 게시글 상세 정보 응답 DTO */
+@Getter
+public class MentosDetailResponse {
+
+    private final Long mentosSeq;
+    private final String mentosTitle;
+    private final String mentosContent;
+    private final int price;
+    private final String mentosImage;
+    private final String mentosPostcode;
+    private final String mentosRoadaddress;
+    private final String mentosBname;
+    private final String mentosDetail;
+    private final String keywordOne;
+    private final String keywordTwo;
+    private final String keywordThree;
+
+    public MentosDetailResponse(Mentos mentos) {
+        this.mentosSeq = mentos.getMentosSeq();
+        this.mentosTitle = mentos.getMentosTitle();
+        this.mentosContent = mentos.getMentosContent();
+        this.price = mentos.getPrice();
+        this.mentosImage = mentos.getMentosImage();
+        this.mentosPostcode = mentos.getMentosPostcode();
+        this.mentosRoadaddress = mentos.getMentosRoadaddress();
+        this.mentosBname = mentos.getMentosBname();
+        this.mentosDetail = mentos.getMentosDetail();
+        this.keywordOne = mentos.getKeywordOne();
+        this.keywordTwo = mentos.getKeywordTwo();
+        this.keywordThree = mentos.getKeywordThree();
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/UpdateMentosRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/UpdateMentosRequest.java
@@ -1,0 +1,44 @@
+package com.shinhanDS5gi.memento.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/* 멘토스 게시글 수정을 위한 요청 DTO */
+@Getter
+@NoArgsConstructor
+public class UpdateMentosRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String mentosTitle;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String mentosContent;
+
+    @NotNull(message = "가격은 필수입니다.")
+    @PositiveOrZero(message = "가격은 0 이상이어야 합니다.")
+    private Integer price;
+
+    @NotBlank(message = "이미지는 필수입니다.")
+    private String mentosImage;
+
+    @NotBlank(message = "우편번호는 필수입니다.")
+    private String mentosPostcode;
+
+    @NotBlank(message = "도로명 주소는 필수입니다.")
+    private String mentosRoadaddress;
+
+    @NotBlank(message = "법정동 이름은 필수입니다.")
+    private String mentosBname;
+
+    private String mentosDetail;
+
+    @NotBlank(message = "첫 번째 키워드는 필수입니다.")
+    private String keywordOne;
+    @NotBlank(message = "두 번째 키워드는 필수입니다.")
+    private String keywordTwo;
+    @NotBlank(message = "세 번째 키워드는 필수입니다.")
+    private String keywordThree;
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MentosRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MentosRepository.java
@@ -1,0 +1,8 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentosRepository extends JpaRepository<Mentos, Long> {
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
@@ -10,4 +10,7 @@ public interface MentosService {
 
     /* 멘토스 게시글 수정 */
     void updateMentos(Long mentosSeq, Long currentMemberId, UpdateMentosRequest requestDto);
+
+    /* 멘토스 게시글 삭제(비활성화)  */
+    void inactiveMentos(Long mentosSeq, Long currentMemberId);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
@@ -1,0 +1,13 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.MentosDetailResponse;
+import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
+
+public interface MentosService {
+
+    /* 기존 멘토스 게시글 정보 조회 */
+    MentosDetailResponse getMentosById(Long mentosSeq);
+
+    /* 멘토스 게시글 수정 */
+    void updateMentos(Long mentosSeq, Long currentMemberId, UpdateMentosRequest requestDto);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -1,0 +1,55 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.dto.MentosDetailResponse;
+import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
+import com.shinhanDS5gi.memento.repository.MentosRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MENTOS;
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.NO_AUTHORITY_TO_UPDATE;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MentosServiceImpl implements MentosService {
+
+    private final MentosRepository mentosRepository;
+
+    @Override
+    public MentosDetailResponse getMentosById(Long mentosSeq) {
+        Mentos mentos = mentosRepository.findById(mentosSeq)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MENTOS));
+        return new MentosDetailResponse(mentos);
+    }
+
+    @Override
+    @Transactional
+    public void updateMentos(Long mentosSeq, Long currentMemberId, UpdateMentosRequest requestDto) {
+        // DB에서 Mentos 엔티티를 조회
+        Mentos mentos = mentosRepository.findById(mentosSeq)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MENTOS));
+
+        // 수정 권한 확인
+        if (!Objects.equals(mentos.getMember().getMemberSeq(), currentMemberId)) {
+            throw new MemberException(NO_AUTHORITY_TO_UPDATE);
+        }
+
+        mentos.setMentosTitle(requestDto.getMentosTitle());
+        mentos.setMentosContent(requestDto.getMentosContent());
+        mentos.setPrice(requestDto.getPrice());
+        mentos.setMentosImage(requestDto.getMentosImage());
+        mentos.setMentosPostcode(requestDto.getMentosPostcode());
+        mentos.setMentosRoadaddress(requestDto.getMentosRoadaddress());
+        mentos.setMentosBname(requestDto.getMentosBname());
+        mentos.setMentosDetail(requestDto.getMentosDetail());
+        mentos.setKeywordOne(requestDto.getKeywordOne());
+        mentos.setKeywordTwo(requestDto.getKeywordTwo());
+        mentos.setKeywordThree(requestDto.getKeywordThree());
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -2,6 +2,7 @@ package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.common.exception.MemberException;
 import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.dto.MentosDetailResponse;
 import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
 import com.shinhanDS5gi.memento.repository.MentosRepository;
@@ -11,8 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
-import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MENTOS;
-import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.NO_AUTHORITY_TO_UPDATE;
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -51,5 +51,20 @@ public class MentosServiceImpl implements MentosService {
         mentos.setKeywordOne(requestDto.getKeywordOne());
         mentos.setKeywordTwo(requestDto.getKeywordTwo());
         mentos.setKeywordThree(requestDto.getKeywordThree());
+    }
+
+    @Override
+    @Transactional
+    public void inactiveMentos(Long mentosSeq, Long currentMemberId) {
+        // 삭제할 멘토스 DB 조회
+        Mentos mentos = mentosRepository.findById(mentosSeq)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MENTOS));
+
+        // 삭제 권한 확인
+        if (!Objects.equals(mentos.getMember().getMemberSeq(), currentMemberId)) {
+            throw new MemberException(NO_AUTHORITY_TO_DELETE);
+        }
+
+        mentos.setStatus(BaseStatus.INACTIVE);
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- 멘토가 개설한 멘토스를 필요시 삭제(비활성화)할 수 있는 기능 (소프트 삭제)
- 실제 데이터가 삭제되는 것이 아닌 Status : active -> inactive로 Patch 변경하는 방식

## 🔑 변경 사항 (Key Changes)

- 멘토스 수정하기 기능 구현 시 Mentos 관련 추가된 파일 중  Service, ServiceImpl, Controller에 삭제 메서드 추가.
- BaseExceptionResponseStatus에 삭제 관련 에러 메시지 enum 추가. (NO_AUTHORITY_TO_DELETE)

## 📝 리뷰 요구사항 (To Reviewers)

- 테스트를 위해 더미 데이터를 우선적으로 Insert 해야 합니다. (Member, Category, Mentos)

-- 1. 카테고리 추가
INSERT INTO category (category_seq, category_name, category_description, status, created_at, modified_at)
VALUES (1, 'IT/개발', '개발 카테고리', 'ACTIVE', NOW(), NOW());

-- 2. 게시글 작성자 추가
INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at)
VALUES (1, 'test_user', 'password123', '테스터', '010-1111-2222', 'MENTO', '2000-01-01', 'ACTIVE', NOW(), NOW());

-- 3. 수정할 멘토링 게시글 추가 
INSERT INTO mentos (mentos_seq, mentos_title, mentos_content, price, mentos_image, mentos_postcode, mentos_roadaddress, mentos_bname, mentos_detail, keyword_one, keyword_two, keyword_three, status, member_seq, category_seq, created_at, modified_at)
VALUES (1, '기존 제목', '기존 내용입니다.', 10000, 'image.jpg', '12345', '서울시 강남구', '역삼동', '상세주소', 'Java', 'Spring', 'JPA', 'ACTIVE', 1, 1, NOW(), NOW());

## 확인 방법 
1. DB에 앞서 얘기한 더미데이터 Insert -> 적용 확인.

<img width="1915" height="943" alt="image" src="https://github.com/user-attachments/assets/9f4a7e7b-5711-4066-83fe-1386e5bf04a0" />
2. Postman을 열고 PATCH 방식으로 http://localhost:9999/mentos/1 send 요청한다.

<img width="1640" height="334" alt="image" src="https://github.com/user-attachments/assets/b1316959-d182-4c3c-9a41-eb8b98d265e9" />
3. 요청에 성공했다는 결과가 뜨면 DB에서 해당 멘토스 데이터의 Status 값이 'INACTIVE'로 변경되어 있으면 테스트 종료.

