### PR TITLE
feat: 회원탈퇴 API구현 완료

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
@@ -23,7 +23,27 @@ public class AuthController {
 
     private final MemberService memberService;
 
-    //로그인
+    /**
+     * 회원 탈퇴
+     */
+    @PatchMapping("/member/{memberSeq}")
+    public BaseResponse<Void> withdraw(@PathVariable Long memberSeq) {
+        memberService.withdraw(memberSeq);
+        return new BaseResponse<>(SUCCESS, null);
+    }
+
+    /**
+     * 로그아웃
+     */
+    @PostMapping("/logout")
+    public BaseResponse<Void> logout(@RequestBody LogoutRequest request) {
+        memberService.logout(request.getMemberSeq());
+        return new BaseResponse<>(SUCCESS, null);
+    }
+
+    /**
+     * 로그인
+     */
     @PostMapping("/login/{user-type}")
     // 페이지 넘기는 값(URL의 {user-type} 값)이 enum의 정확한 이름과 동일하면  MemberType으로 바인딩
     public BaseResponse<LoginResponse> login(@PathVariable("user-type") MemberType type,
@@ -33,15 +53,10 @@ public class AuthController {
         //성공 응답 리턴
         return new BaseResponse<>(SUCCESS, new LoginResponse(member.getMemberName()));
     }
-  
-    //로그아웃
-    @PostMapping("/logout")
-    public BaseResponse<Void> logout(@RequestBody LogoutRequest request) {
-        memberService.logout(request.getMemberSeq());
-        return new BaseResponse<>(SUCCESS, null);
-    }
 
-    // 회원가입 (멘토)
+    /**
+     * 멘토 회원가입
+     */
     @PostMapping("/signup/mento")
     public BaseResponse<Void> signupMento(@RequestBody MentoSignupRequest requestDto) {
 
@@ -51,8 +66,10 @@ public class AuthController {
         // 성공 응답 리턴
         return new BaseResponse<>(SUCCESS, null);
     }
-    
-    // 회원가입 (멘티)
+
+    /**
+     * 멘티 회원가입
+     */
     @PostMapping("/signup/menti")
     public BaseResponse<Void> signupMenti(@RequestBody MentiSignupRequest requestDto) {
 

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.shinhanDS5gi.memento.repository;
 
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.member.MemberType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,8 +8,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    //회원 탈퇴
+    //(memberSeq로 status가 ACTIVE 상태인지 조회)
+    Optional<Member> findByMemberSeqAndStatus(Long memberSeq, BaseStatus status);
+
     //로그인
-    //멤버아이디와 멤버타입을 동시에 만족하는 멤버엔티티를 DB에서 찾는다.(멘토/멘티/관리자)
+    //(멤버아이디와 멤버타입을 동시에 만족하는 멤버엔티티를 DB에서 찾는다.(멘토/멘티/관리자))
     Optional<Member> findByMemberIdAndMemberType(String memberId, MemberType type);
 
     //로그인 시 아이디 중복확인을 위해 작성

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
@@ -7,8 +7,11 @@ import com.shinhanDS5gi.memento.dto.MentiSignupRequest;
 import com.shinhanDS5gi.memento.dto.MentoSignupRequest;
 
 public interface MemberService {
-    
-    //아이디와 타입보고 로그인
+
+    //회원탈퇴
+    void withdraw(Long memberSeq);
+
+    //로그인 (아이디와 멤버타입확인)
     Member login(MemberType pathType, LoginRequest request);
     
     //로그아웃

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
@@ -2,7 +2,6 @@ package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.common.exception.AuthException;
 import com.shinhanDS5gi.memento.common.exception.MemberException;
-import com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus;
 import com.shinhanDS5gi.memento.domain.MentoCertification;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
@@ -13,12 +12,12 @@ import com.shinhanDS5gi.memento.dto.MentoSignupRequest;
 import com.shinhanDS5gi.memento.dto.MentiSignupRequest;
 import com.shinhanDS5gi.memento.repository.MemberRepository;
 import com.shinhanDS5gi.memento.repository.MentoCertificationRepository;
+import org.springframework.beans.DirectFieldAccessor;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
-
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +26,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.*;
 
 @Slf4j
 @Service
@@ -37,6 +38,30 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepo;
     private final PasswordEncoder pwEncoder;
     private final MentoCertificationRepository certRepo;
+
+    /**
+     * 회원탈퇴
+     */
+    @Override
+    @Transactional
+    public void withdraw(Long memberSeq) { // 회원 PK로 탈퇴 수행
+        // 1) ACTIVE인 회원만 찾음 → 없거나 이미 INACTIVE면 바로 오류메세지
+        Member member = memberRepo.findByMemberSeqAndStatus(memberSeq, BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+        // 2) status를 INACTIVE로 변경
+        new DirectFieldAccessor(member).setPropertyValue("status", BaseStatus.INACTIVE);
+        // 종료 시 커밋 → UPDATE 자동 실행(더티체킹)
+    }
+    /**
+     * 로그아웃
+     */
+    @Override
+    public void logout(Long memberSeq) {
+        //memberSeq를 가진 멤버를 member테이블에서 조회
+        memberRepo.findById(memberSeq)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+        log.info("로그아웃 성공: memberSeq={}", memberSeq);
+    }
 
     /**
      * 로그인 기능
@@ -53,12 +78,11 @@ public class MemberServiceImpl implements MemberService {
             Member admin = adminOpt.get();
             if (!pwEncoder.matches(rawPwd, admin.getMemberPwd())) {
                 log.warn("로그인 실패: 비밀번호 틀림 (id={}, type=ADMIN)", id);
-                throw new AuthException(BaseExceptionResponseStatus.INVALID_PASSWORD);
+                throw new AuthException(INVALID_PASSWORD);
             }
             log.info("로그인 성공: (id={}, type=ADMIN)", id);
             return admin;
         }
-
         // 2) 선택한 타입(MENTO/MENTI) 로그인 처리
         Optional<Member> userOpt = memberRepo.findByMemberIdAndMemberType(id, pathType);
         if (!userOpt.isPresent()) {
@@ -68,34 +92,24 @@ public class MemberServiceImpl implements MemberService {
 
             if (otherOpt.isPresent()) {
                 log.warn("로그인 실패: 타입 불일치 (id={}, 선택한 타입={})", id, pathType);
-                throw new AuthException(BaseExceptionResponseStatus.CANNOT_LOGIN);
+                throw new AuthException(CANNOT_LOGIN);
             } else {
                 log.warn("로그인 실패: 아이디 불일치 (id={})", id);
-                throw new AuthException(BaseExceptionResponseStatus.INVALID_MEMBER_ID);
+                throw new AuthException(INVALID_MEMBER_ID);
             }
         }
-
         // 3) 비밀번호 검증
         Member user = userOpt.get();
         if (!pwEncoder.matches(rawPwd, user.getMemberPwd())) {
             log.warn("로그인 실패: 비밀번호 틀림 (id={}, type={})", id, user.getMemberType());
-            throw new AuthException(BaseExceptionResponseStatus.INVALID_PASSWORD);
+            throw new AuthException(INVALID_PASSWORD);
         }
 
         log.info("로그인 성공: (id={}, type={})", id, user.getMemberType());
         return user;
     }
 
-    /**
-     * 로그아웃
-     */  
 
-    @Override
-    public void logout(Long memberSeq) {
-            memberRepo.findById(memberSeq) //memberSeq를 가진 멤버를 member테이블에서 조회
-                    .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
-            log.info("로그아웃 성공: memberSeq={}", memberSeq);
-        }
 
 
     /**
@@ -103,12 +117,13 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public void signupMento(MentoSignupRequest req) {
+        // 1) 중복 아이디 체크
         if (memberRepo.existsByMemberId(req.getMemberId())) {
-            throw new MemberException(BaseExceptionResponseStatus.CANNOT_SIGNUP);
+            throw new MemberException(CANNOT_SIGNUP);
         }
-
+        // 2) 생년월일 파싱 (yyyy-MM-dd)
         LocalDate birth = LocalDate.parse(req.getMemberBirthDate());
-
+        // 3) 엔티티에 회원 저장 (MENTO)
         Member member = Member.builder()
                 .memberId(req.getMemberId())
                 .memberPwd(pwEncoder.encode(req.getMemberPwd()))
@@ -119,15 +134,18 @@ public class MemberServiceImpl implements MemberService {
                 .status(BaseStatus.ACTIVE)
                 .build();
         memberRepo.save(member);
-
+        // 4) 자격증 저장
         List<MentoCertificationRequest> certReqs = req.getCertification();
+        //자격증 없으면 스킵처리 / 있으면 저장
         if (certReqs != null && !certReqs.isEmpty()) {
+            //DTO를 엔티티로 변환해서 List에 저장
             List<MentoCertification> entities = new ArrayList<>(certReqs.size());
+            //자격증 하나씩 처리
             for (MentoCertificationRequest c : certReqs) {
                 entities.add(new MentoCertification(
-                        null,
-                        c.getCertificationName(),
-                        c.getCertificationFile(),
+                        null, // PK 자동
+                        c.getCertificationName(), // mentoCertificationName
+                        c.getCertificationFile(), // mentoCertificationImage
                         BaseStatus.ACTIVE,
                         member
                 ));
@@ -141,12 +159,13 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public void signupMenti(MentiSignupRequest req) {
+        // 1) 중복 아이디 체크
         if (memberRepo.existsByMemberId(req.getMemberId())) {
-            throw new MemberException(BaseExceptionResponseStatus.CANNOT_SIGNUP);
+            throw new MemberException(CANNOT_SIGNUP);
         }
-
+        // 2) 생년월일 파싱 (yyyy-MM-dd)
         LocalDate birth = LocalDate.parse(req.getMemberBirthDate());
-
+        // 3) 엔티티에 회원 저장 (MENTI)
         Member m = Member.builder()
                 .memberId(req.getMemberId())
                 .memberPwd(pwEncoder.encode(req.getMemberPwd()))


### PR DESCRIPTION
## 요약 (Summary)
- [x] 작업 내용 요약
- 회원탈퇴 구현
- Restful한 설계로 API 백엔드 작업 구현

## 🔑 변경 사항 (Key Changes)
- 회원탈퇴관련 Controller,Repository ,Service, ServiceImpl 코드추가
- 이외 기존 코드 변경사항 없음

## 📝 리뷰 요구사항 (To Reviewers)
비밀번호 해시 때문에 아래 사진처럼 비밀번호를 출력하게 해놓았습니다. 
서버를 실행시키면 ENC_1234 과ENC_admin 에 나오는 코드를 보고 DB insert 할때 member_pwd칸에 넣어주세요 
<img width="895" height="510" alt="image" src="https://github.com/user-attachments/assets/a62fef19-7e2f-4627-81f5-069f897bbab8" />


```
INSERT INTO member (member_id, member_pwd, member_name, member_type, member_phone_number, member_birth_date, created_at)
VALUES
  ('menti01', '{ENC_1234}', '멘티', 'MENTI', '010-1111-1111', '2000-01-01',NOW() ),
  ('mento01', '{ENC_1234}', '멘토', 'MENTO', '010-2222-2222', '1999-01-01',NOW() ),
  ('admin',   '{ENC_admin}', '관리자', 'ADMIN', '010-9999-9999', '1990-01-01',NOW() );
```
{ENC_1234},{ENC_admin} 이걸 삭제하고 알맞게 넣어주시면 됩니다.

아래 사진처럼 넣어주시면 insert 됩니다. 
<img width="1600" height="972" alt="image" src="https://github.com/user-attachments/assets/ef9199ca-f36b-4b25-ac44-1622aeac25a8" />

## 확인 방법 
POSTMAN에 들어가서
PATCH 에 `http://localhost:9999/auth/member/1` 로 url를 작성해주고
body선택 raw선택 아래 코드 입력
```
{
	 "memberSeq": 1
}
```
사진처럼 확인 
<img width="739" height="661" alt="image" src="https://github.com/user-attachments/assets/32ee5c07-7c6d-4c8a-9fcf-e1a43b76356f" />
POSTMAN으로 요청 성공한 거  확인하면 DB 가서 status INACTIVE인지 확인
<img width="1729" height="287" alt="image" src="https://github.com/user-attachments/assets/ea52ed89-cc93-4438-8ae4-a83e25e67a14" />

다시 한번 더 똑같이 POSTMAN으로 요청 하면 404 오류 뜨는거 확인 
-> 탈퇴한사람 또 탈퇴 처리로 중복 처리 방지
<img width="741" height="670" alt="image" src="https://github.com/user-attachments/assets/fa3a40f4-eff4-4197-9c20-e0e9e1ba9ac7" />


