### PR TITLE
feat : 나의 프로필 정보 조회 API 기능 구현 완료

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/MyPageController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MyPageController.java
@@ -2,13 +2,12 @@ package com.shinhanDS5gi.memento.controller;
 
 import com.shinhanDS5gi.memento.common.response.BaseResponse;
 import com.shinhanDS5gi.memento.dto.CreateReviewRequest;
+import com.shinhanDS5gi.memento.dto.MyProfileResponse;
+import com.shinhanDS5gi.memento.service.MyPageService;
 import com.shinhanDS5gi.memento.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
 
@@ -19,6 +18,7 @@ import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionRespo
 public class MyPageController {
 
     private final ReviewService reviewService;
+    private final MyPageService myPageService;
 
     /* 리뷰 작성하기 */
     @PostMapping("/reviews")
@@ -26,5 +26,13 @@ public class MyPageController {
         Long currentMemberId = 1L;
         reviewService.createReview(currentMemberId, requestDto);
         return new BaseResponse<>(SUCCESS, null);
+    }
+
+    /* 나의 프로필 조회하기 */
+    @GetMapping("/profile")
+    public BaseResponse<MyProfileResponse> getMyProfile() {
+        Long currentMemberId = 1L;
+        MyProfileResponse profile = myPageService.getMyProfile(currentMemberId);
+        return new BaseResponse<>(SUCCESS, profile);
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/MyProfileResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/MyProfileResponse.java
@@ -1,0 +1,17 @@
+package com.shinhanDS5gi.memento.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+/* 나의 프로필 조회를 위한 응답 DTO*/
+@Getter
+@Builder
+public class MyProfileResponse {
+
+    private final String memberName;
+    private final String memberPhoneNumber;
+    private final LocalDate memberBirthDate;
+    private final String memberId;
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MyPageService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MyPageService.java
@@ -1,0 +1,9 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.MyProfileResponse;
+
+public interface MyPageService {
+
+    /* 나의 프로필 정보 조회 */
+    MyProfileResponse getMyProfile(Long memberSeq);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
@@ -21,7 +21,7 @@ public class MyPageServiceImpl implements MyPageService {
     @Override
     public MyProfileResponse getMyProfile(Long memberSeq) {
 
-        Member member = memberRepository.findById(memberSeq)
+        Member member = memberRepository.findByMemberSeqAndStatus(memberSeq, BaseStatus.ACTIVE)
                 .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
 
         return MyProfileResponse.builder()

--- a/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
@@ -1,0 +1,34 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.dto.MyProfileResponse;
+import com.shinhanDS5gi.memento.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageServiceImpl implements MyPageService {
+
+    private final MemberRepository memberRepository;
+    
+    /* 나의 프로필 정보 조회 */
+    @Override
+    public MyProfileResponse getMyProfile(Long memberSeq) {
+
+        Member member = memberRepository.findById(memberSeq)
+                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+
+        return MyProfileResponse.builder()
+                .memberName(member.getMemberName())
+                .memberPhoneNumber(member.getMemberPhoneNumber())
+                .memberBirthDate(member.getMemberBirthDate())
+                .memberId(member.getMemberId())
+                .build();
+    }
+}


### PR DESCRIPTION
## 요약 (Summary)
- 회원의 나의 정보 관리 화면에서 비춰지는 나의 프로필 정보를 조회하는 기능 구현
<img width="574" height="749" alt="image" src="https://github.com/user-attachments/assets/06043c9e-404b-4c69-8988-8866cb431ce4" />


- 해당 이미지에서 확인할 수 있듯이 이름, 전화번호, 생년월일, 아이디 정보를 확인할 수 있음.

## 🔑 변경 사항 (Key Changes)

-  해당 기능 구현을 위해 MypageController, MyPageService, ServiceImpl 신규 생성 및 프로필 정보를 담은 응답 DTO 'MyProfileResponse' 생성

## 📝 리뷰 요구사항 (To Reviewers)

- 회원 정보는 편의를 위해 임의로 '1L'로 규정해 두었음.
- 테스트를 위해 Member_Seq가 1인 member 더미데이터를 insert 해야 함.

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at)
VALUES (1, 'gayeon_user', 'password123', '안가연', '010-1234-5678', 'MENTI', '2001-05-10', 'ACTIVE', NOW(), NOW())
ON DUPLICATE KEY UPDATE member_id = 'test_user';

## 확인 방법 
1. Postman 실행 후 Get 요청 방식으로 'http://localhost:9999/mypage/profile' URL 설정해 Send한다. (현재 member_seq는 1임)
<img width="1903" height="866" alt="image" src="https://github.com/user-attachments/assets/417f474a-64ba-4616-8bd1-4c833b36edce" />
2. 위의 이미지처럼 요청에 성공했다는 메시지와 함께 알맞은 회원 프로필 정보 데이터가 결과값으로 표시되면 테스트 종료.