### PR TITLE
feat: 멘토스 전체 조회

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/common/exception/CategoryException.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception/CategoryException.java
@@ -1,0 +1,19 @@
+package com.shinhanDS5gi.memento.common.exception;
+
+import com.shinhanDS5gi.memento.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class CategoryException extends RuntimeException{
+    final ResponseStatus exceptionStatus;
+
+    public CategoryException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public CategoryException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/common/exception_handler/CategoryExceptionControllerAdvice.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception_handler/CategoryExceptionControllerAdvice.java
@@ -1,0 +1,22 @@
+package com.shinhanDS5gi.memento.common.exception_handler;
+
+import com.shinhanDS5gi.memento.common.exception.CategoryException;
+import com.shinhanDS5gi.memento.common.response.BaseErrorResponse;
+import jakarta.annotation.Priority;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Priority(0)
+@RestControllerAdvice
+public class CategoryExceptionControllerAdvice {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(CategoryException.class)
+    public BaseErrorResponse handle_CategoryException(CategoryException e) {
+        log.error("[handle_CategoryException]", e);
+        return new BaseErrorResponse(e.getExceptionStatus(), e.getMessage());
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -41,6 +41,10 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     CANNOT_LOGIN(5003,HttpStatus.BAD_REQUEST.value(),"로그인에 실패했습니다."),
 
     /**
+     * Category 관련 7000대
+     */
+    CANNOT_FOUND_CATEGORY(7000, HttpStatus.BAD_REQUEST.value(),"해당 카테고리를 찾을 수 없습니다."),
+    /**
      * Report 관련 8000대
      */
     CANNOT_FOUND_REPORT(8000, HttpStatus.NOT_FOUND.value(), "해당 ID의 신고 내역을 찾을 수 없습니다."),

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -4,6 +4,7 @@ import com.shinhanDS5gi.memento.common.response.BaseResponse;
 import com.shinhanDS5gi.memento.dto.MyMentosResponse;
 import com.shinhanDS5gi.memento.dto.MyMentosSliceResponse;
 import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
+import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
 import com.shinhanDS5gi.memento.service.MentosService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,5 +47,15 @@ public class MentosController {
         mentosService.inactiveMentos(mentosSeq, currentMemberId);
 
         return new BaseResponse<>(SUCCESS, null);
+    }
+
+    /* 멘토스 전체 조회 */
+    @GetMapping("/category/{mentosCategorySeq}")
+    public BaseResponse<GetMentosListResponse> getMentosList(
+            @PathVariable("mentosCategorySeq") Long mentosCategorySeq,
+            @RequestParam(value = "limit", defaultValue = "10") Integer limit,
+            @RequestParam(value = "cursor", required = false) Long cursor){
+        log.info("[MentosController.getMentosList]");
+        return new BaseResponse<>(mentosService.getMentosList(mentosCategorySeq, limit, cursor));
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
@@ -1,0 +1,28 @@
+package com.shinhanDS5gi.memento.dto.mentos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetMentosListResponse {
+
+    private List<MentosDetail> mentos;
+    private boolean hasNext;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MentosDetail{
+        private Long mentosSeq;
+        private boolean isApproved;
+        private String mentosImg;
+        private String mentosTitle;
+        private int mentosPrice;
+        private String region;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
@@ -3,11 +3,13 @@ package com.shinhanDS5gi.memento.dto.mentos;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class GetMentosListResponse {
 
@@ -17,6 +19,7 @@ public class GetMentosListResponse {
     @Getter
     @Builder
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class MentosDetail{
         private Long mentosSeq;
         private boolean isApproved;

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
@@ -1,5 +1,6 @@
 package com.shinhanDS5gi.memento.dto.mentos;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +23,7 @@ public class GetMentosListResponse {
     @NoArgsConstructor
     public static class MentosDetail{
         private Long mentosSeq;
-        private boolean isApproved;
+        private boolean approved;
         private String mentosImg;
         private String mentosTitle;
         private int mentosPrice;

--- a/src/main/java/com/shinhanDS5gi/memento/repository/CategoryRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.shinhanDS5gi.memento.repository;
+
+import com.shinhanDS5gi.memento.domain.Category;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByCategorySeqAndStatus(Long categorySeq, BaseStatus status);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosCustomRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosCustomRepository.java
@@ -1,6 +1,5 @@
 package com.shinhanDS5gi.memento.repository.mentos;
 
-import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
 
@@ -8,5 +7,6 @@ import java.util.List;
 
 public interface MentosCustomRepository {
 
+    /* 멘토스 전체조회(카테고리별) */
     List<GetMentosListResponse.MentosDetail> findAllByCategorySeqAndLimitAndCursor(Long mentosCategorySeq, Integer limit, Long cursor, BaseStatus status);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosCustomRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosCustomRepository.java
@@ -1,0 +1,12 @@
+package com.shinhanDS5gi.memento.repository.mentos;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
+
+import java.util.List;
+
+public interface MentosCustomRepository {
+
+    List<GetMentosListResponse.MentosDetail> findAllByCategorySeqAndLimitAndCursor(Long mentosCategorySeq, Integer limit, Long cursor, BaseStatus status);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepository.java
@@ -9,14 +9,13 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface MentosRepository extends JpaRepository<Mentos, Long>, MentosCustomRepository {
 
     /* 접속한 멘토 유저의 활성화된 멘토스 목록 조회 */
     @Query("SELECT m FROM Mentos m WHERE m.member.memberSeq = :memberSeq AND m.status = :status AND m.mentosSeq < :cursor ORDER BY m.mentosSeq DESC")
     Slice<Mentos> findMyMentosSlice(@Param("memberSeq") Long memberSeq, @Param("cursor") Long cursor, @Param("status") BaseStatus status, Pageable pageable);
 
+    /* 멘토스 전체조회(카테고리별) */
     @Modifying(clearAutomatically = true)
     @Query("update Mentos m set m.status = :afterStatus where m.member.memberSeq = :memberSeq and m.status = :beforeStatus")
     int updateMentosStatus(@Param("memberSeq") Long memberSeq,

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepository.java
@@ -1,4 +1,4 @@
-package com.shinhanDS5gi.memento.repository;
+package com.shinhanDS5gi.memento.repository.mentos;
 
 import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface MentosRepository extends JpaRepository<Mentos, Long> {
+public interface MentosRepository extends JpaRepository<Mentos, Long>, MentosCustomRepository {
 
     /* 접속한 멘토 유저의 활성화된 멘토스 목록 조회 */
     @Query("SELECT m FROM Mentos m WHERE m.member.memberSeq = :memberSeq AND m.status = :status AND m.mentosSeq < :cursor ORDER BY m.mentosSeq DESC")

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
@@ -34,7 +34,7 @@ public class MentosRepositoryImpl implements MentosCustomRepository {
             builder.and(mentos.mentosSeq.lt(cursor));
         }
 
-        BooleanExpression existsApproved = JPAExpressions.selectOne().from(certification).where(certification.member.eq(mentos.member), certification.status.eq(status)).exists();
+        BooleanExpression existsApproved = JPAExpressions.selectOne().from(certification).where(certification.member.memberSeq.eq(mentos.member.memberSeq), certification.status.eq(status)).exists();
 
         return queryFactory.select(Projections.fields(GetMentosListResponse.MentosDetail.class,
                         mentos.mentosSeq,
@@ -42,7 +42,7 @@ public class MentosRepositoryImpl implements MentosCustomRepository {
                         mentos.mentosTitle,
                         mentos.price.as("mentosPrice"),
                         mentos.mentosBname.as("region"),
-                        new CaseBuilder().when(existsApproved).then(true).otherwise(false).as("isApproved")))
+                        new CaseBuilder().when(existsApproved).then(true).otherwise(false).as("approved")))
                 .from(mentos)
                 .where(builder)
                 .orderBy(mentos.mentosSeq.desc())

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
@@ -23,6 +23,7 @@ public class MentosRepositoryImpl implements MentosCustomRepository {
     QMentos mentos = QMentos.mentos;
     QMentoCertification certification = QMentoCertification.mentoCertification;
 
+    /* 멘토스 전체조회(카테고리별) */
     @Override
     public List<GetMentosListResponse.MentosDetail> findAllByCategorySeqAndLimitAndCursor(Long mentosCategorySeq, Integer limit, Long cursor, BaseStatus status) {
         // where 절에 들어갈 쿼리문

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.shinhanDS5gi.memento.repository.mentos;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.shinhanDS5gi.memento.domain.QMentoCertification;
+import com.shinhanDS5gi.memento.domain.QMentos;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MentosRepositoryImpl implements MentosCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+    QMentos mentos = QMentos.mentos;
+    QMentoCertification certification = QMentoCertification.mentoCertification;
+
+    @Override
+    public List<GetMentosListResponse.MentosDetail> findAllByCategorySeqAndLimitAndCursor(Long mentosCategorySeq, Integer limit, Long cursor, BaseStatus status) {
+        // where 절에 들어갈 쿼리문
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(mentos.status.eq(status)).and(mentos.category.categorySeq.eq(mentosCategorySeq));
+
+        if (cursor != null) {
+            builder.and(mentos.mentosSeq.lt(cursor));
+        }
+
+        BooleanExpression existsApproved = JPAExpressions.selectOne().from(certification).where(certification.member.eq(mentos.member), certification.status.eq(status)).exists();
+
+        return queryFactory.select(Projections.fields(GetMentosListResponse.MentosDetail.class,
+                        mentos.mentosSeq,
+                        mentos.mentosImage.as("mentosImg"),
+                        mentos.mentosTitle,
+                        mentos.price.as("mentosPrice"),
+                        mentos.mentosBname.as("region"),
+                        new CaseBuilder().when(existsApproved).then(true).otherwise(false).as("isApproved")))
+                .from(mentos)
+                .where(builder)
+                .orderBy(mentos.mentosSeq.desc())
+                .limit(limit + 1)
+                .fetch();
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
@@ -14,11 +14,11 @@ import com.shinhanDS5gi.memento.dto.admin.GetMemberListResponse;
 import com.shinhanDS5gi.memento.repository.MentoCertificationRepository;
 import com.shinhanDS5gi.memento.repository.*;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
+import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import org.springframework.beans.DirectFieldAccessor;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
@@ -16,5 +16,6 @@ public interface MentosService {
     /* 멘토스 게시글 삭제(비활성화)  */
     void inactiveMentos(Long mentosSeq, Long currentMemberId);
 
+    /* 멘토스 전체조회(카테고리별) */
     GetMentosListResponse getMentosList(Long mentosCategorySeq, Integer limit, Long cursor);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
@@ -3,6 +3,7 @@ package com.shinhanDS5gi.memento.service;
 import com.shinhanDS5gi.memento.dto.MyMentosResponse;
 import com.shinhanDS5gi.memento.dto.MyMentosSliceResponse;
 import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
+import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
 
 public interface MentosService {
 
@@ -14,4 +15,6 @@ public interface MentosService {
 
     /* 멘토스 게시글 삭제(비활성화)  */
     void inactiveMentos(Long mentosSeq, Long currentMemberId);
+
+    GetMentosListResponse getMentosList(Long mentosCategorySeq, Integer limit, Long cursor);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -1,13 +1,16 @@
 package com.shinhanDS5gi.memento.service;
 
+import com.shinhanDS5gi.memento.common.exception.CategoryException;
 import com.shinhanDS5gi.memento.common.exception.MemberException;
 import com.shinhanDS5gi.memento.common.exception.MentosException;
+import com.shinhanDS5gi.memento.domain.Category;
 import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.dto.MyMentosResponse;
 import com.shinhanDS5gi.memento.dto.MyMentosSliceResponse;
 import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
 import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
+import com.shinhanDS5gi.memento.repository.CategoryRepository;
 import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +32,7 @@ import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionRespo
 public class MentosServiceImpl implements MentosService {
 
     private final MentosRepository mentosRepository;
+    private final CategoryRepository categoryRepository;
 
     /* 멘토가 개설한 멘토스 중 Status가 'ACTIVE'인 멘토스만 모두 조회하기 (무한스크롤 페이징 처리) */
     @Override
@@ -120,12 +124,17 @@ public class MentosServiceImpl implements MentosService {
     @Override
     public GetMentosListResponse getMentosList(Long mentosCategorySeq, Integer limit, Long cursor) {
         log.info("[MentosServiceImpl.getMentosList]");
+
+        Category category = categoryRepository.findByCategorySeqAndStatus(mentosCategorySeq, BaseStatus.ACTIVE).orElseThrow(
+                () -> new CategoryException(CANNOT_FOUND_CATEGORY)
+        );
+
         List<GetMentosListResponse.MentosDetail> mentosDetailList = mentosRepository.findAllByCategorySeqAndLimitAndCursor(mentosCategorySeq, limit, cursor, BaseStatus.ACTIVE);
 
         GetMentosListResponse result;
-        if(mentosDetailList.size()<=limit){
+        if (mentosDetailList.size() <= limit) {
             result = GetMentosListResponse.builder().mentos(mentosDetailList.stream().limit(limit).toList()).hasNext(false).build();
-        }else{
+        } else {
             result = GetMentosListResponse.builder().mentos(mentosDetailList.stream().limit(limit).toList()).hasNext(true).build();
         }
         return result;

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -116,6 +116,7 @@ public class MentosServiceImpl implements MentosService {
         mentos.setStatus(BaseStatus.INACTIVE);
     }
 
+    /* 멘토스 전체조회(카테고리별) */
     @Override
     public GetMentosListResponse getMentosList(Long mentosCategorySeq, Integer limit, Long cursor) {
         log.info("[MentosServiceImpl.getMentosList]");

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -7,8 +7,10 @@ import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.dto.MyMentosResponse;
 import com.shinhanDS5gi.memento.dto.MyMentosSliceResponse;
 import com.shinhanDS5gi.memento.dto.UpdateMentosRequest;
-import com.shinhanDS5gi.memento.repository.MentosRepository;
+import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
+import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -111,5 +114,19 @@ public class MentosServiceImpl implements MentosService {
         }
 
         mentos.setStatus(BaseStatus.INACTIVE);
+    }
+
+    @Override
+    public GetMentosListResponse getMentosList(Long mentosCategorySeq, Integer limit, Long cursor) {
+        log.info("[MentosServiceImpl.getMentosList]");
+        List<GetMentosListResponse.MentosDetail> mentosDetailList = mentosRepository.findAllByCategorySeqAndLimitAndCursor(mentosCategorySeq, limit, cursor, BaseStatus.ACTIVE);
+
+        GetMentosListResponse result;
+        if(mentosDetailList.size()<=limit){
+            result = GetMentosListResponse.builder().mentos(mentosDetailList.stream().limit(limit).toList()).hasNext(false).build();
+        }else{
+            result = GetMentosListResponse.builder().mentos(mentosDetailList.stream().limit(limit).toList()).hasNext(true).build();
+        }
+        return result;
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -8,7 +8,7 @@ import com.shinhanDS5gi.memento.domain.report.Report;
 import com.shinhanDS5gi.memento.dto.CreateReportRequest;
 import com.shinhanDS5gi.memento.dto.SelectReportResponse;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
-import com.shinhanDS5gi.memento.repository.MentosRepository;
+import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import com.shinhanDS5gi.memento.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
@@ -10,7 +10,7 @@ import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.dto.CreateReviewRequest;
 import com.shinhanDS5gi.memento.dto.MentoReviewsListResponse;
 import com.shinhanDS5gi.memento.dto.MentoReviewsSliceResponse;
-import com.shinhanDS5gi.memento.repository.MentosRepository;
+import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import com.shinhanDS5gi.memento.repository.ReservationRepository;
 import com.shinhanDS5gi.memento.repository.ReviewRepository;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;


### PR DESCRIPTION
## 요약 (Summary)
- [x] 홈화면에서 카테고리를 누르면 들어가지는 화면에서의 멘토스 전체조회 api 구현하였습니다. 카테고리 기준으로 최신 데이터를 우선적으로 보여줍니다.
- [x] 이전 관리자 페이지의 무한스크롤과 동일한 방법으로 구현된 무한스크롤입니다.
- [x] query dsl 로 한번에 데이터를 받아와서 dto 와 매핑시켰습니다.

## 🔑 변경 사항 (Key Changes)
- `dto.mentos 디렉토리 생성`( 혹시 이전에 mentos 관련 dto 작성하셨다면.. 다음 작업에서 이 디렉토리로 옮겨주시면 감사하겠습니다 :) )
- `MentosController.getMentosList 구현`
- `GetMentosListResponse 작성`
- `MentosCustomRepository Interface 구현`, `MentosRepository Interface 구현`, `MentosRepositoryImpl 구현`
- `MentosServiceImpl.getMentosList 구현`
- 
<img width="416" height="572" alt="스크린샷 2025-08-27 10 50 33" src="https://github.com/user-attachments/assets/32cc0b43-e5b4-40e6-85c6-ae264267e49a" />
"approved" 필드를 채우려면 mentos 의 memberSeq 를 가지고 mento_certification 테이블에서 select 해서 자격증 여부를 확인해야했는데, 첨부한 사진처럼 단일 select 문으로 1개의 쿼리문으로 모두 해결하였습니다!

## 📝 리뷰 요구사항 (To Reviewers)

- [x] api 명세서대로 동작하고 반환되는지 [api 명세서 바로가기](https://paint-doll-0ba.notion.site/253fa60ecd058081aafdfb9c6a89a196?source=copy_link)
- [x] 존재하지 않는 카테고리가 들어오면 적절하게 예외처리가 되는지

## 확인 방법 
```
INSERT INTO category (category_name, category_description, created_at, status) VALUES
('소비패턴',  '지출 패턴 분석과 고정비 절감, 실생활 소비 최적화',        NOW(6), 'ACTIVE'),
('생활노하우','생활비 절약·정리·자동화 등 실전 생활 팁',                   NOW(6), 'ACTIVE'),
('저축방식',  '목표기반 저축, 예적금/연금/자동이체 등 저축 전략',           NOW(6), 'ACTIVE'),
('자산증식',  'ETF·배당·채권·자산배분 등 장기 투자와 포트폴리오 운용',     NOW(6), 'ACTIVE');

INSERT INTO member (
    member_birth_date,
    created_at,
    modified_at,
    member_id,
    member_name,
    member_phone_number,
    member_pwd,
    member_type,
    status
) VALUES
('1990-01-01', NOW(), NULL, 'user01', '홍길동', '010-0000-0001', 'pw0001', 'MENTI', 'ACTIVE'),
('1991-02-02', NOW(), NULL, 'user02', '김철수', '010-0000-0002', 'pw0002', 'MENTO', 'ACTIVE'),
('1992-03-03', NOW(), NULL, 'user03', '이영희', '010-0000-0003', 'pw0003', 'MENTI', 'ACTIVE'),
('1993-04-04', NOW(), NULL, 'user04', '박민수', '010-0000-0004', 'pw0004', 'MENTO', 'ACTIVE'),
('1994-05-05', NOW(), NULL, 'user05', '최지우', '010-0000-0005', 'pw0005', 'ADMIN', 'ACTIVE'),
('1995-06-06', NOW(), NULL, 'user06', '정하늘', '010-0000-0006', 'pw0006', 'MENTO', 'ACTIVE'),
('1996-07-07', NOW(), NULL, 'user07', '오세훈', '010-0000-0007', 'pw0007', 'MENTI', 'ACTIVE'),
('1997-08-08', NOW(), NULL, 'user08', '윤아름', '010-0000-0008', 'pw0008', 'MENTO', 'ACTIVE'),
('1998-09-09', NOW(), NULL, 'user09', '장도연', '010-0000-0009', 'pw0009', 'MENTI', 'ACTIVE'),
('1999-10-10', NOW(), NULL, 'user10', '한가인', '010-0000-0010', 'pw0010', 'MENTO', 'ACTIVE'),
('2000-11-11', NOW(), NULL, 'user11', '서준호', '010-0000-0011', 'pw0011', 'ADMIN', 'ACTIVE'),
('2001-12-12', NOW(), NULL, 'user12', '배수지', '010-0000-0012', 'pw0012', 'MENTI', 'ACTIVE'),
('1990-03-13', NOW(), NULL, 'user13', '강호동', '010-0000-0013', 'pw0013', 'MENTO', 'ACTIVE'),
('1991-04-14', NOW(), NULL, 'user14', '유재석', '010-0000-0014', 'pw0014', 'MENTI', 'ACTIVE'),
('1992-05-15', NOW(), NULL, 'user15', '신동엽', '010-0000-0015', 'pw0015', 'MENTO', 'ACTIVE'),
('1993-06-16', NOW(), NULL, 'user16', '김희철', '010-0000-0016', 'pw0016', 'MENTI', 'ACTIVE'),
('1994-07-17', NOW(), NULL, 'user17', '이수근', '010-0000-0017', 'pw0017', 'MENTO', 'ACTIVE'),
('1995-08-18', NOW(), NULL, 'user18', '서장훈', '010-0000-0018', 'pw0018', 'ADMIN', 'ACTIVE'),
('1996-09-19', NOW(), NULL, 'user19', '송중기', '010-0000-0019', 'pw0019', 'MENTO', 'ACTIVE'),
('1997-10-20', NOW(), NULL, 'user20', '아이유', '010-0000-0020', 'pw0020', 'MENTI', 'ACTIVE');

INSERT INTO mento_certification (
    member_seq,
    mento_certification_name,
    mento_certification_image,
    created_at,
    modified_at,
    status
) VALUES (
    2,
    '정보처리기사',
    'https://example.com/certifications/it_engineer.png',
    NOW(6),
    NULL,
    'ACTIVE'
);


INSERT INTO mentos
(price, category_seq, created_at, member_seq, keyword_one, keyword_two, keyword_three,
 mentos_bname, mentos_content, mentos_detail, mentos_image, mentos_postcode, mentos_roadaddress, mentos_title, status)
VALUES
(35000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 2, '지출분석','가계부','패턴파악','연남동','지출 패턴을 분석해 불필요한 비용을 줄여요', NULL, 'https://picsum.photos/seed/pattern01/400/300','03995','서울 마포구 연남로 1','[소비패턴] 멘토스 #01','ACTIVE'),
(30000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 2, '고정비절감','구독관리','리뷰','망원동','구독 결제와 고정비를 정리하는 방법', NULL, 'https://picsum.photos/seed/pattern02/400/300','04001','서울 마포구 월드컵로 2','[소비패턴] 멘토스 #02','ACTIVE'),
(40000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 2, '체크리스트','불필요소비','알림','합정동','불필요 소비를 줄이는 체크리스트 만들기', NULL, 'https://picsum.photos/seed/pattern03/400/300','04003','서울 마포구 양화로 3','[소비패턴] 멘토스 #03','ACTIVE'),
(28000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 4, '가계부앱','카테고리','분석','성수동','카테고리별 소비 분석과 앱 활용법', NULL, 'https://picsum.photos/seed/pattern04/400/300','04790','서울 성동구 성수이로 4','[소비패턴] 멘토스 #04','ACTIVE'),
(45000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 4, '현금흐름','예산배분','피드백','잠실동','월 예산 배분과 현금흐름 점검', NULL, 'https://picsum.photos/seed/pattern05/400/300','05500','서울 송파구 올림픽로 5','[소비패턴] 멘토스 #05','ACTIVE'),
(32000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 4, '식비절감','장보기','밀프렙','구의동','식비를 줄이는 장보기/밀프렙 노하우', NULL, 'https://picsum.photos/seed/pattern06/400/300','05010','서울 광진구 아차산로 6','[소비패턴] 멘토스 #06','ACTIVE'),
(38000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 4, '교통비','이동패턴','최적화','연남동','이동 패턴 기반 교통비 최적화', NULL, 'https://picsum.photos/seed/pattern07/400/300','03995','서울 마포구 연남로 7','[소비패턴] 멘토스 #07','ACTIVE'),
(26000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 6, '문화생활','티켓관리','캘린더','망원동','문화/여가 소비 예산 세우기', NULL, 'https://picsum.photos/seed/pattern08/400/300','04001','서울 마포구 월드컵로 8','[소비패턴] 멘토스 #08','ACTIVE'),
(33000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 6, '의류비','시즌세일','계획구매','합정동','계획형 쇼핑으로 의류비 줄이기', NULL, 'https://picsum.photos/seed/pattern09/400/300','04003','서울 마포구 양화로 9','[소비패턴] 멘토스 #09','ACTIVE'),
(27000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 6, '카드혜택','실적관리','포인트','성수동','카드 실적/혜택 최적화', NULL, 'https://picsum.photos/seed/pattern10/400/300','04790','서울 성동구 성수이로 10','[소비패턴] 멘토스 #10','ACTIVE'),
(34000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 6, '유틸리티','전기요금','누진제','잠실동','공과금 줄이는 팁(전기/수도/가스)', NULL, 'https://picsum.photos/seed/pattern11/400/300','05500','서울 송파구 올림픽로 11','[소비패턴] 멘토스 #11','ACTIVE'),
(29000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 6, '보험료','중복보장','점검','구의동','보험료 점검과 중복보장 정리', NULL, 'https://picsum.photos/seed/pattern12/400/300','05010','서울 광진구 아차산로 12','[소비패턴] 멘토스 #12','ACTIVE'),
(36000, (SELECT category_seq FROM category WHERE category_name='소비패턴'), NOW(6), 8, '가전렌탈','약정관리','대체안','연남동','렌탈/약정 비용 관리와 대체안 찾기', NULL, 'https://picsum.photos/seed/pattern13/400/300','03995','서울 마포구 연남로 13','[소비패턴] 멘토스 #13','ACTIVE');

INSERT INTO mentos
(price, category_seq, created_at, member_seq, keyword_one, keyword_two, keyword_three,
 mentos_bname, mentos_content, mentos_detail, mentos_image, mentos_postcode, mentos_roadaddress, mentos_title, status)
VALUES
(30000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 8, '생활비절약','정리수납','소분','망원동','생활 전반의 비용을 줄이는 노하우', NULL, 'https://picsum.photos/seed/life01/400/300','04001','서울 마포구 월드컵로 21','[생활노하우] 멘토스 #01','ACTIVE'),
(32000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 8, '공동구매','쿠폰','적립금','합정동','공동구매/쿠폰/적립금으로 절약하기', NULL, 'https://picsum.photos/seed/life02/400/300','04003','서울 마포구 양화로 22','[생활노하우] 멘토스 #02','ACTIVE'),
(28000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 8, '식재료관리','냉장고정리','유통기한','성수동','장바구니/식재료 관리 루틴', NULL, 'https://picsum.photos/seed/life03/400/300','04790','서울 성동구 성수이로 23','[생활노하우] 멘토스 #03','ACTIVE'),
(35000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 8, '광고차단','가격추적','알림','잠실동','가격 추적/광고 차단으로 충동구매 방지', NULL, 'https://picsum.photos/seed/life04/400/300','05500','서울 송파구 올림픽로 24','[생활노하우] 멘토스 #04','ACTIVE'),
(26000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 6, 'DIY수리','셀프인테리어','공구','구의동','셀프 수리/인테리어로 비용 절감', NULL, 'https://picsum.photos/seed/life05/400/300','05010','서울 광진구 아차산로 25','[생활노하우] 멘토스 #05','ACTIVE'),
(33000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 6, '통신비','알뜰폰','요금제','연남동','통신비/인터넷 요금 최적화', NULL, 'https://picsum.photos/seed/life06/400/300','03995','서울 마포구 연남로 26','[생활노하우] 멘토스 #06','ACTIVE'),
(27000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 6, '세탁팁','오염제거','수선','망원동','세탁/수선으로 의류 수명 늘리기', NULL, 'https://picsum.photos/seed/life07/400/300','04001','서울 마포구 월드컵로 27','[생활노하우] 멘토스 #07','ACTIVE'),
(34000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 4, '청소루틴','소모품','재사용','합정동','청소 루틴으로 시간/비용 절감', NULL, 'https://picsum.photos/seed/life08/400/300','04003','서울 마포구 양화로 28','[생활노하우] 멘토스 #08','ACTIVE'),
(29000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 4, '에너지절약','단열','타이머','성수동','전기/가스 절약 실전 팁', NULL, 'https://picsum.photos/seed/life09/400/300','04790','서울 성동구 성수이로 29','[생활노하우] 멘토스 #09','ACTIVE'),
(31000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 4, '가사자동화','앱루틴','리마인더','잠실동','앱/자동화로 가사효율화', NULL, 'https://picsum.photos/seed/life10/400/300','05500','서울 송파구 올림픽로 30','[생활노하우] 멘토스 #10','ACTIVE'),
(36000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 4, '공구대여','커뮤니티','공유경제','구의동','공유경제 활용으로 지출 줄이기', NULL, 'https://picsum.photos/seed/life11/400/300','05010','서울 광진구 아차산로 31','[생활노하우] 멘토스 #11','ACTIVE'),
(30000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 2, '식단루틴','배달줄이기','홈쿠킹','연남동','배달 줄이고 홈쿠킹 루틴 만들기', NULL, 'https://picsum.photos/seed/life12/400/300','03995','서울 마포구 연남로 32','[생활노하우] 멘토스 #12','ACTIVE'),
(35000, (SELECT category_seq FROM category WHERE category_name='생활노하우'), NOW(6), 2, '금융일정','자동이체','알림','망원동','공과금/납부일 관리 자동화', NULL, 'https://picsum.photos/seed/life13/400/300','04001','서울 마포구 월드컵로 33','[생활노하우] 멘토스 #13','ACTIVE');

INSERT INTO mentos
(price, category_seq, created_at, member_seq, keyword_one, keyword_two, keyword_three,
 mentos_bname, mentos_content, mentos_detail, mentos_image, mentos_postcode, mentos_roadaddress, mentos_title, status)
VALUES
(30000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 2, '파킹통장','예적금','목표저축','합정동','파킹/예적금으로 기본 수익 올리기', NULL, 'https://picsum.photos/seed/save01/400/300','04003','서울 마포구 양화로 41','[저축방식] 멘토스 #01','ACTIVE'),
(32000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 2, '버킷리스트','목표관리','캘린더','성수동','버킷 기반 목표 저축 설계', NULL, 'https://picsum.photos/seed/save02/400/300','04790','서울 성동구 성수이로 42','[저축방식] 멘토스 #02','ACTIVE'),
(28000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 4, '자동이체','우선저축','비상금','잠실동','월급 먼저 저축/비상금 만들기', NULL, 'https://picsum.photos/seed/save03/400/300','05500','서울 송파구 올림픽로 43','[저축방식] 멘토스 #03','ACTIVE'),
(35000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 4, '적금쪼개기','분리계좌','통장쪼개기','구의동','통장 쪼개기로 목적별 저축', NULL, 'https://picsum.photos/seed/save04/400/300','05010','서울 광진구 아차산로 44','[저축방식] 멘토스 #04','ACTIVE'),
(26000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 4, '챌린지','주차저축','습관화','연남동','주차 저축/챌린지로 습관 만들기', NULL, 'https://picsum.photos/seed/save05/400/300','03995','서울 마포구 연남로 45','[저축방식] 멘토스 #05','ACTIVE'),
(34000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 4, 'IRP','연금저축','세액공제','망원동','연금저축/IRP 세액공제 활용', NULL, 'https://picsum.photos/seed/save06/400/300','04001','서울 마포구 월드컵로 46','[저축방식] 멘토스 #06','ACTIVE'),
(29000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 8, '저축률','동기부여','루틴','합정동','저축률 끌어올리는 루틴', NULL, 'https://picsum.photos/seed/save07/400/300','04003','서울 마포구 양화로 47','[저축방식] 멘토스 #07','ACTIVE'),
(31000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 8, '목돈만들기','단기저축','CD금리','성수동','단기 목돈 만들기 전략', NULL, 'https://picsum.photos/seed/save08/400/300','04790','서울 성동구 성수이로 48','[저축방식] 멘토스 #08','ACTIVE'),
(36000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 8, '적금리밸런싱','만기관리','갈아타기','잠실동','만기 관리/금리 갈아타기', NULL, 'https://picsum.photos/seed/save09/400/300','05500','서울 송파구 올림픽로 49','[저축방식] 멘토스 #09','ACTIVE'),
(30000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 8, '라떼저축','챌린지','동기부여','구의동','소액 꾸준 저축 미션', NULL, 'https://picsum.photos/seed/save10/400/300','05010','서울 광진구 아차산로 50','[저축방식] 멘토스 #10','ACTIVE'),
(35000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 8, '상여/세금','연말정산','우선저축','연남동','상여/환급금으로 저축률 끌어올리기', NULL, 'https://picsum.photos/seed/save11/400/300','03995','서울 마포구 연남로 51','[저축방식] 멘토스 #11','ACTIVE'),
(27000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 6, '변동금리','고정금리','분산','망원동','금리환경 대응 저축 포트폴리오', NULL, 'https://picsum.photos/seed/save12/400/300','04001','서울 마포구 월드컵로 52','[저축방식] 멘토스 #12','ACTIVE'),
(34000, (SELECT category_seq FROM category WHERE category_name='저축방식'), NOW(6), 6, '리밸런싱','목표점검','자동화','합정동','저축 리밸런싱과 자동화', NULL, 'https://picsum.photos/seed/save13/400/300','04003','서울 마포구 양화로 53','[저축방식] 멘토스 #13','ACTIVE');

INSERT INTO mentos
(price, category_seq, created_at, member_seq, keyword_one, keyword_two, keyword_three,
 mentos_bname, mentos_content, mentos_detail, mentos_image, mentos_postcode, mentos_roadaddress, mentos_title, status)
VALUES
(40000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 6, '인덱스투자','ETF','분산','성수동','인덱스/ETF로 분산 투자 시작하기', NULL, 'https://picsum.photos/seed/grow01/400/300','04790','서울 성동구 성수이로 61','[자산증식] 멘토스 #01','ACTIVE'),
(38000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 6, '배당주','현금흐름','DRIP','잠실동','배당주로 현금흐름 만들기', NULL, 'https://picsum.photos/seed/grow02/400/300','05500','서울 송파구 올림픽로 62','[자산증식] 멘토스 #02','ACTIVE'),
(42000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 4, '적립식','장기투자','복리','구의동','적립식 장기투자와 복리의 힘', NULL, 'https://picsum.photos/seed/grow03/400/300','05010','서울 광진구 아차산로 63','[자산증식] 멘토스 #03','ACTIVE'),
(36000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 4, '채권','MMF','리스크관리','연남동','채권/현금성 자산으로 변동성 완화', NULL, 'https://picsum.photos/seed/grow04/400/300','03995','서울 마포구 연남로 64','[자산증식] 멘토스 #04','ACTIVE'),
(45000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 4, '자산배분','리밸런싱','포트폴리오','망원동','자산배분/리밸런싱 전략', NULL, 'https://picsum.photos/seed/grow05/400/300','04001','서울 마포구 월드컵로 65','[자산증식] 멘토스 #05','ACTIVE'),
(39000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '리스크관리','DDM','밸류에이션','합정동','기초 밸류에이션과 리스크 관리', NULL, 'https://picsum.photos/seed/grow06/400/300','04003','서울 마포구 양화로 66','[자산증식] 멘토스 #06','ACTIVE'),
(41000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '리츠','부동산간접','분산','성수동','리츠/부동산 간접투자 이해', NULL, 'https://picsum.photos/seed/grow07/400/300','04790','서울 성동구 성수이로 67','[자산증식] 멘토스 #07','ACTIVE'),
(37000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '테마ETF','섹터분산','리스크','잠실동','섹터/테마 ETF 분산과 주의점', NULL, 'https://picsum.photos/seed/grow08/400/300','05500','서울 송파구 올림픽로 68','[자산증식] 멘토스 #08','ACTIVE'),
(43000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '해외분산','환헤지','세금','구의동','해외 자산 분산/환리스크/세금 기초', NULL, 'https://picsum.photos/seed/grow09/400/300','05010','서울 광진구 아차산로 69','[자산증식] 멘토스 #09','ACTIVE'),
(35000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '목표수익','규칙','손절/익절','연남동','목표 수익/손절 규칙 세우기', NULL, 'https://picsum.photos/seed/grow10/400/300','03995','서울 마포구 연남로 70','[자산증식] 멘토스 #10','ACTIVE'),
(39000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '백테스트','리포트','점검','망원동','간단 백테스트/리포트 점검', NULL, 'https://picsum.photos/seed/grow11/400/300','04001','서울 마포구 월드컵로 71','[자산증식] 멘토스 #11','ACTIVE'),
(41000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '세제혜택','연금','장기','합정동','세제혜택 활용 장기 자산 증식', NULL, 'https://picsum.photos/seed/grow12/400/300','04003','서울 마포구 양화로 72','[자산증식] 멘토스 #12','ACTIVE'),
(44000, (SELECT category_seq FROM category WHERE category_name='자산증식'), NOW(6), 2, '분할매수','현금비중','심리관리','성수동','분할매수/현금비중/심리관리', NULL, 'https://picsum.photos/seed/grow13/400/300','04790','서울 성동구 성수이로 73','[자산증식] 멘토스 #13','ACTIVE');

```
위의 쿼리문을 실행시켜주세요.

그 다음 아래의 주소로 get 요청 보내주세요.
```
http://localhost:9999/mentos/category/{categorySeq}?limit=10&cursor=4
```

limit 와 cursor 는 필요에 따라서 작성해주세요.

<img width="1585" height="888" alt="스크린샷 2025-08-27 10 42 47" src="https://github.com/user-attachments/assets/5b4e089b-ed31-4e2f-92fb-e74e1d98a90e" />

다음과 같이 반환되는 것을 확인할 수 있습니다. 

<img width="1585" height="888" alt="스크린샷 2025-08-27 11 08 27" src="https://github.com/user-attachments/assets/ed270897-9b82-4ff7-be46-f8ec13c5abe8" />

4가 넘어가는 카테고리 seq 로 요청보내면 예외처리해두었습니다.