### PR TITLE
feat : 멘토 프로필 수정하기 API 기능 구현 완료

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/common/exception/MentoCertificationException.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception/MentoCertificationException.java
@@ -1,0 +1,20 @@
+package com.shinhanDS5gi.memento.common.exception;
+
+import com.shinhanDS5gi.memento.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class MentoCertificationException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public MentoCertificationException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public MentoCertificationException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/common/exception/ReviewException.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/exception/ReviewException.java
@@ -1,0 +1,20 @@
+package com.shinhanDS5gi.memento.common.exception;
+
+import com.shinhanDS5gi.memento.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class ReviewException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public ReviewException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public ReviewException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
@@ -1,11 +1,7 @@
 package com.shinhanDS5gi.memento.controller;
 
 import com.shinhanDS5gi.memento.common.response.BaseResponse;
-import com.shinhanDS5gi.memento.dto.CreateMentoCertificationRequest;
-import com.shinhanDS5gi.memento.dto.CreateMentoProfileRequest;
-import com.shinhanDS5gi.memento.dto.MentoReviewsListResponse;
-import com.shinhanDS5gi.memento.dto.MentoReviewsSliceResponse;
-import com.shinhanDS5gi.memento.dto.MyMentiResponse;
+import com.shinhanDS5gi.memento.dto.*;
 import com.shinhanDS5gi.memento.service.MentoCertificationService;
 import com.shinhanDS5gi.memento.service.MentoProfileService;
 import com.shinhanDS5gi.memento.service.MentoService;
@@ -56,6 +52,16 @@ public class MentoController {
 
         Long currentMemberId = 1L; // 임시 사용자 ID
         mentoProfileService.createMentoProfile(currentMemberId, requestDto);
+
+        return new BaseResponse<>(SUCCESS, null);
+    }
+
+    /* 멘토 프로필 수정 */
+    @PatchMapping("/mento-profiles")
+    public BaseResponse<Void> updateMentoProfile(@RequestBody UpdateMentoProfileRequest requestDto) {
+
+        Long currentMemberId = 1L;
+        mentoProfileService.updateMentoProfile(currentMemberId, requestDto);
 
         return new BaseResponse<>(SUCCESS, null);
     }

--- a/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
@@ -32,8 +32,8 @@ public class MentoProfile extends BaseTime {
     private BaseStatus status;
 
     @JsonIgnore
-    @OneToOne(fetch = FetchType.LAZY, optional = true) // 반드시 있어야 하면 optional=false
-    @JoinColumn(name = "member_seq", unique = true)    // ★ unique로 1:1 보장
+    @OneToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "member_seq", unique = true)
     private Member member;
 
     /* 멘토 프로필 수정하기 */

--- a/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.base.BaseTime;
 import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.dto.UpdateMentoProfileRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -34,4 +35,10 @@ public class MentoProfile extends BaseTime {
     @OneToOne(fetch = FetchType.LAZY, optional = true) // 반드시 있어야 하면 optional=false
     @JoinColumn(name = "member_seq", unique = true)    // ★ unique로 1:1 보장
     private Member member;
+
+    /* 멘토 프로필 수정하기 */
+    public void update(UpdateMentoProfileRequest requestDto) {
+        this.mentoProfileContent = requestDto.getMentoProfileContent();
+        this.mentoProfileImage = requestDto.getMentoProfileImage();
+    }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/UpdateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/UpdateMentoProfileRequest.java
@@ -1,0 +1,17 @@
+package com.shinhanDS5gi.memento.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/* 멘토 프로필 수정을 위한 요청 DTO */
+@Getter
+@NoArgsConstructor
+public class UpdateMentoProfileRequest {
+
+    @NotBlank(message = "멘토 소개 내용은 필수입니다.")
+    private String mentoProfileContent;
+
+    @NotBlank(message = "프로필 이미지는 필수입니다.")
+    private String mentoProfileImage;
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/MentoProfileRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/MentoProfileRepository.java
@@ -19,4 +19,7 @@ public interface MentoProfileRepository extends JpaRepository<MentoProfile, Long
     int updateMentoProfileStatus(@Param("memberSeq") Long memberSeq,
                                        @Param("afterStatus") BaseStatus afterStatus,
                                        @Param("beforeStatus") BaseStatus beforeStatus);
+
+    /* memberSeq에 맞는 mentoProfile 조회 */
+    Optional<MentoProfile> findByMember_MemberSeq(Long memberSeq);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationServiceImpl.java
@@ -1,6 +1,6 @@
 package com.shinhanDS5gi.memento.service;
 
-import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.common.exception.MentoCertificationException;
 import com.shinhanDS5gi.memento.domain.MentoCertification;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.member.MemberType;
@@ -30,11 +30,11 @@ public class MentoCertificationServiceImpl implements MentoCertificationService 
     public void createMentoCertification(Long memberSeq, CreateMentoCertificationRequest requestDto) {
         // 1. 사용자 조회
         Member member = memberRepository.findById(memberSeq)
-                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+                .orElseThrow(() -> new MentoCertificationException(CANNOT_FOUND_MEMBER));
 
         // 2. 멘토 타입인지 검증
         if (member.getMemberType() != MemberType.MENTO) {
-            throw new MemberException(NOT_A_MENTO);
+            throw new MentoCertificationException(NOT_A_MENTO);
         }
 
         // 3. DTO 리스트를 엔티티 리스트로 변환

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
@@ -1,9 +1,13 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.dto.CreateMentoProfileRequest;
+import com.shinhanDS5gi.memento.dto.UpdateMentoProfileRequest;
 
 public interface MentoProfileService {
 
     /* 신규 멘토 프로필 생성 */
     void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto);
+
+    /* 멘토 프로필 수정 */
+    void updateMentoProfile(Long memberSeq, UpdateMentoProfileRequest requestDto);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
@@ -1,10 +1,12 @@
 package com.shinhanDS5gi.memento.service;
 
-import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.common.exception.MentoProfileException;
 import com.shinhanDS5gi.memento.domain.MentoProfile;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.member.MemberType;
 import com.shinhanDS5gi.memento.dto.CreateMentoProfileRequest;
+import com.shinhanDS5gi.memento.dto.UpdateMentoProfileRequest;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import com.shinhanDS5gi.memento.repository.MentoProfileRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,25 +23,42 @@ public class MentoProfileServiceImpl implements MentoProfileService {
     private final MentoProfileRepository mentoProfileRepository;
     private final MemberRepository memberRepository;
 
+    /* 멘토 프로필 생성 */
     @Override
     @Transactional
     public void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto) {
 
         /* 회원 가입한 사용자인가? */
         Member member = memberRepository.findById(memberSeq)
-                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
+                .orElseThrow(() -> new MentoProfileException(CANNOT_FOUND_MEMBER));
 
         /* 멘토인가? */
         if (member.getMemberType() != MemberType.MENTO) {
-            throw new MemberException(FAILURE, "멘토 회원만 프로필을 생성할 수 있습니다.");
+            throw new MentoProfileException(FAILURE, "멘토 회원만 프로필을 생성할 수 있습니다.");
         }
 
         /* 이미 멘토프로필 생성하진 않았는가? */
         if (mentoProfileRepository.existsByMember_MemberSeq(memberSeq)) {
-            throw new MemberException(ALREADY_EXISTS_MENTO_PROFILE);
+            throw new MentoProfileException(ALREADY_EXISTS_MENTO_PROFILE);
         }
 
         MentoProfile mentoProfile = requestDto.toEntity(member);
         mentoProfileRepository.save(mentoProfile);
+    }
+
+    /* 멘토 프로필 수정 */
+    @Override
+    @Transactional
+    public void updateMentoProfile(Long memberSeq, UpdateMentoProfileRequest requestDto) {
+
+        /* 회원 가입한 사용자인가? */
+        memberRepository.findByMemberSeqAndStatus(memberSeq, BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MentoProfileException(CANNOT_FOUND_MEMBER));
+
+        /* 수정할 프로필을 조회 */
+        MentoProfile mentoProfile = mentoProfileRepository.findByMember_MemberSeq(memberSeq)
+                .orElseThrow(() -> new MentoProfileException(CANNOT_FOUND_MENTO_PROFILE));
+
+        mentoProfile.update(requestDto);
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -1,6 +1,5 @@
 package com.shinhanDS5gi.memento.service;
 
-import com.shinhanDS5gi.memento.common.exception.MemberException;
 import com.shinhanDS5gi.memento.common.exception.MentosException;
 import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
@@ -77,11 +76,11 @@ public class MentosServiceImpl implements MentosService {
     public void updateMentos(Long mentosSeq, Long currentMemberId, UpdateMentosRequest requestDto) {
         // DB에서 Mentos 엔티티를 조회
         Mentos mentos = mentosRepository.findById(mentosSeq)
-                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MENTOS));
+                .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTOS));
 
         // 수정 권한 확인
         if (!Objects.equals(mentos.getMember().getMemberSeq(), currentMemberId)) {
-            throw new MemberException(NO_AUTHORITY_TO_UPDATE);
+            throw new MentosException(NO_AUTHORITY_TO_UPDATE);
         }
 
         mentos.setMentosTitle(requestDto.getMentosTitle());
@@ -103,11 +102,11 @@ public class MentosServiceImpl implements MentosService {
     public void inactiveMentos(Long mentosSeq, Long currentMemberId) {
         // 삭제할 멘토스 DB 조회
         Mentos mentos = mentosRepository.findById(mentosSeq)
-                .orElseThrow(() -> new MemberException(CANNOT_FOUND_MENTOS));
+                .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTOS));
 
         // 삭제 권한 확인
         if (!Objects.equals(mentos.getMember().getMemberSeq(), currentMemberId)) {
-            throw new MemberException(NO_AUTHORITY_TO_DELETE);
+            throw new MentosException(NO_AUTHORITY_TO_DELETE);
         }
 
         mentos.setStatus(BaseStatus.INACTIVE);

--- a/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
@@ -1,6 +1,7 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.dto.MyProfileResponse;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -1,6 +1,5 @@
 package com.shinhanDS5gi.memento.service;
 
-import com.shinhanDS5gi.memento.common.exception.MemberException;
 import com.shinhanDS5gi.memento.common.exception.ReportException;
 import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.member.Member;
@@ -33,7 +32,7 @@ public class ReportServiceImpl implements ReportService {
     @Override
     @Transactional
     public void createReport(Long memberSeq, CreateReportRequest requestDto) {
-        Member reporter = memberRepository.findById(memberSeq).orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
+        Member reporter = memberRepository.findById(memberSeq).orElseThrow(()-> new ReportException(CANNOT_FOUND_MEMBER));
         Mentos reportedMentos = mentosRepository.findById(requestDto.getMentosSeq())
                 .orElseThrow(() -> new ReportException(CANNOT_FOUND_REPORT));
         Report report = requestDto.toEntity(reporter, reportedMentos);

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
@@ -1,7 +1,6 @@
 package com.shinhanDS5gi.memento.service;
 
-import com.shinhanDS5gi.memento.common.exception.MemberException;
-import com.shinhanDS5gi.memento.common.exception.MentosException;
+import com.shinhanDS5gi.memento.common.exception.ReviewException;
 import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.Reservation;
 import com.shinhanDS5gi.memento.domain.Review;
@@ -40,7 +39,7 @@ public class ReviewServiceImpl implements ReviewService {
 
         //리뷰 없을 경우
         if (cursor == null && rows.isEmpty()) {
-            throw new MentosException(NO_REVIEWS_FOUND_FOR_MENTO);
+            throw new ReviewException(NO_REVIEWS_FOUND_FOR_MENTO);
         }
         // 2) 다음 페이지 여부 판단 (limit보다 많으면 hasNext = true)
         boolean hasNext = rows.size() > limit;
@@ -66,21 +65,21 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     public void createReview(Long memberSeq, CreateReviewRequest requestDto) {
         /* 리뷰 작성자(유저), 리뷰 대상(멘토스) 조회 */
-        Member reviewer = memberRepository.findById(memberSeq).orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
-        Mentos reviewedMentos = mentosRepository.findById(requestDto.getMentosSeq()).orElseThrow(()-> new MentosException(CANNOT_FOUND_MENTOS));
+        Member reviewer = memberRepository.findById(memberSeq).orElseThrow(()-> new ReviewException(CANNOT_FOUND_MEMBER));
+        Mentos reviewedMentos = mentosRepository.findById(requestDto.getMentosSeq()).orElseThrow(()-> new ReviewException(CANNOT_FOUND_MENTOS));
 
         /* 실제로 멘토스를 예약한 유저인가? */
         Reservation reservation = reservationRepository.findByMember_MemberSeqAndMentos_MentosSeq(memberSeq, requestDto.getMentosSeq())
-                .orElseThrow(() -> new MemberException(FAILURE, "해당 멘토스를 수강한 내역이 없어 리뷰를 작성할 수 없습니다."));
+                .orElseThrow(() -> new ReviewException(FAILURE, "해당 멘토스를 수강한 내역이 없어 리뷰를 작성할 수 없습니다."));
 
         /* 진행 완료된 멘토스인가? */
         if (reservation.getMentosAt().isAfter(LocalDateTime.now())) {
-            throw new MemberException(FAILURE, "아직 진행하지 않은 멘토스에 대한 리뷰는 작성할 수 없습니다.");
+            throw new ReviewException(FAILURE, "아직 진행하지 않은 멘토스에 대한 리뷰는 작성할 수 없습니다.");
         }
 
         /* 이미 리뷰를 작성한 멘토스는 아닌가? */
         if (reviewRepository.existsByMember_MemberSeqAndMentos_MentosSeq(memberSeq, requestDto.getMentosSeq())) {
-            throw new MemberException(FAILURE, "이미 리뷰를 작성한 멘토스입니다.");
+            throw new ReviewException(FAILURE, "이미 리뷰를 작성한 멘토스입니다.");
         }
 
         Review review = requestDto.toEntity(reviewer, reviewedMentos);


### PR DESCRIPTION
## 요약 (Summary)
- 멘토 첫 로그인 시 입력받은 멘토 프로필 (멘토 프로필 사진, 프로필 소개 내용)에 대해 필요 시 수정할 수 있게 하는 API 기능 구현.
- 나의 프로필 수정과 같은 페이지에 버튼이 있지만, 멘토 프로필 생성과 가장 연관성이 있기 때문에 MyPageController가 아닌 MentoController에 해당 메서드 배치함.
- 예외 처리를 위해 Exception 클래스 파일 신규 생성 (MentoProfileException, MentosException, ReviewException 등)

## 🔑 변경 사항 (Key Changes)

-  MentoController, MentoProfileServiceImpl에 멘토 프로필 수정과 관련된 메서드 추가.
- MentoProfile 도메인에 update 함수 추가
- UpdateMentoProfileRequest DTO 신규 생성

## 📝 리뷰 요구사항 (To Reviewers)

- 멘토 프로필 수정 테스트를 진행하기 위해 Member와 MentoProfile 테이블에 더미데이터(멘토인 멤버) 삽입 필요.

-- 1. 멘토 회원(member_seq=1) 추가
INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at)
VALUES (1, 'mentor_user', 'password123', '김멘토', '010-1111-1111', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW())
ON DUPLICATE KEY UPDATE member_id = 'mentor_user'; 

-- 2. 위 멘토의 프로필(member_seq=1) 추가
INSERT INTO mento_profile (mento_profile_seq, mento_profile_content, mento_profile_image, status, member_seq, created_at, modified_at)
VALUES (1, '안녕하세요, 기존 프로필 내용입니다.', 'https://example.com/original.jpg', 'ACTIVE', 1, NOW(), NOW())
ON DUPLICATE KEY UPDATE mento_profile_content = '안녕하세요, 기존 프로필 내용입니다.'; 

## 확인 방법 
1. 더미데이터가 알맞게 삽입되었는지 확인 후 Postman을 열고 Patch 요청 방식으로 'http://localhost:9999/mento/mento-profiles' 경로로 설정한다.

2. Body-raw-JSON 방식 채택 후 JSON 형태의 아래 요청 사항을 작성해 Send한다.
{
  "mentoProfileContent": "프로필 내용이 새롭게 수정되었습니다. 잘 부탁드립니다!",
  "mentoProfileImage": "https://example.com/new_image.png"
}
<img width="1482" height="536" alt="image" src="https://github.com/user-attachments/assets/5311c56c-cf34-47e4-a0c1-63f8ebdd33a0" />

3. 요청에 성공했다는 메시지 확인 후 DB에서 해당 memberSeq의 회원의 멘토 프로필 정보가 수정되었는지 확인 후 알맞게 변경되었으면 테스트를 종료한다.
<img width="1105" height="218" alt="image" src="https://github.com/user-attachments/assets/3d1ad5a6-2e0e-4aff-a2b0-46455a5b00eb" />
