### PR TITLE
feat : 나의 멘토스 내역 조회 (멘티 기준) API 기능 구현 완료

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/MyPageController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MyPageController.java
@@ -2,6 +2,7 @@ package com.shinhanDS5gi.memento.controller;
 
 import com.shinhanDS5gi.memento.common.response.BaseResponse;
 import com.shinhanDS5gi.memento.dto.CreateReviewRequest;
+import com.shinhanDS5gi.memento.dto.MyMentosByMentiSliceResponse;
 import com.shinhanDS5gi.memento.dto.MyProfileResponse;
 import com.shinhanDS5gi.memento.service.MyPageService;
 import com.shinhanDS5gi.memento.service.ReviewService;
@@ -34,5 +35,16 @@ public class MyPageController {
         Long currentMemberId = 1L;
         MyProfileResponse profile = myPageService.getMyProfile(currentMemberId);
         return new BaseResponse<>(SUCCESS, profile);
+    }
+
+    /* 나의 멘토스 내역 조회하기 (멘티 기준) */
+    @GetMapping("/my-mentos-list")
+    public BaseResponse<MyMentosByMentiSliceResponse> getMyMentoringHistory(
+            @RequestParam(defaultValue = "3") int limit, // 3개씩 보여주기
+            @RequestParam(required = false) Long cursor
+    ) {
+        Long currentMemberId = 1L;
+        var page = myPageService.getMyMentosByMenti(currentMemberId, limit, cursor);
+        return new BaseResponse<>(SUCCESS, page);
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/MyMentosByMentiResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/MyMentosByMentiResponse.java
@@ -1,0 +1,34 @@
+package com.shinhanDS5gi.memento.dto;
+
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.Reservation;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyMentosByMentiResponse {
+
+    private final Long mentosSeq;
+    private final String mentosTitle;
+    private final String mentosImage;
+    private final int price;
+    private final String region;
+    private final String progressStatus; /* 진행 전 | 진행 완료 */
+
+    public static MyMentosByMentiResponse from(Reservation reservation) {
+        Mentos mentos = reservation.getMentos();
+        String status = reservation.getMentosAt().isBefore(LocalDateTime.now()) ? "진행 완료" : "진행 전";
+
+        return MyMentosByMentiResponse.builder()
+                .mentosSeq(mentos.getMentosSeq())
+                .mentosTitle(mentos.getMentosTitle())
+                .mentosImage(mentos.getMentosImage())
+                .price(mentos.getPrice())
+                .region(mentos.getMentosBname())
+                .progressStatus(status)
+                .build();
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/MyMentosByMentiSliceResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/MyMentosByMentiSliceResponse.java
@@ -1,0 +1,14 @@
+
+package com.shinhanDS5gi.memento.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class MyMentosByMentiSliceResponse {
+    private final List<MyMentosByMentiResponse> content;
+    private final Long nextCursor;
+    private final boolean hasNext;
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReservationRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReservationRepository.java
@@ -1,6 +1,8 @@
 package com.shinhanDS5gi.memento.repository;
 
 import com.shinhanDS5gi.memento.domain.Reservation;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +19,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("SELECT r FROM Reservation r JOIN FETCH r.mentos m JOIN FETCH r.member menti WHERE m.member.memberSeq = :mentorId AND r.status = 'ACTIVE' ORDER BY m.mentosSeq, r.mentosAt")
     List<Reservation> findAllByMentorId(@Param("mentorId") Long mentorId);
 
+    /* 특정 멘티의 멘토스 예약 목록을 커서 기반 페이징으로 조회 */
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.mentos m WHERE r.member.memberSeq = :memberSeq AND r.status = :status AND r.reservationSeq < :cursor ORDER BY r.reservationSeq DESC")
+    Slice<Reservation> findByMemberSeqWithSlice(@Param("memberSeq") Long memberSeq, @Param("cursor") Long cursor, @Param("status") BaseStatus status, Pageable pageable);
 
     @Modifying(clearAutomatically = true)
     @Query("update Reservation r set r.status = :afterStatus where r.member.memberSeq = :memberSeq and r.status = :beforeStatus")

--- a/src/main/java/com/shinhanDS5gi/memento/service/MyPageService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MyPageService.java
@@ -1,9 +1,13 @@
 package com.shinhanDS5gi.memento.service;
 
+import com.shinhanDS5gi.memento.dto.MyMentosByMentiSliceResponse;
 import com.shinhanDS5gi.memento.dto.MyProfileResponse;
 
 public interface MyPageService {
 
     /* 나의 프로필 정보 조회 */
     MyProfileResponse getMyProfile(Long memberSeq);
+
+    /* 나의 멘토스 내역 조회(멘티 기준) */
+    MyMentosByMentiSliceResponse getMyMentosByMenti(Long memberSeq, int limit, Long cursor);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
@@ -1,12 +1,21 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.domain.Reservation;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.dto.MyMentosByMentiResponse;
+import com.shinhanDS5gi.memento.dto.MyMentosByMentiSliceResponse;
 import com.shinhanDS5gi.memento.dto.MyProfileResponse;
+import com.shinhanDS5gi.memento.repository.ReservationRepository;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
 
@@ -16,6 +25,7 @@ import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionRespo
 public class MyPageServiceImpl implements MyPageService {
 
     private final MemberRepository memberRepository;
+    private final ReservationRepository reservationRepository;
     
     /* 나의 프로필 정보 조회 */
     @Override
@@ -29,6 +39,32 @@ public class MyPageServiceImpl implements MyPageService {
                 .memberPhoneNumber(member.getMemberPhoneNumber())
                 .memberBirthDate(member.getMemberBirthDate())
                 .memberId(member.getMemberId())
+                .build();
+    }
+
+    /* 나의 멘토스 내역 조회 (멘티 기준) */
+    @Override
+    public MyMentosByMentiSliceResponse getMyMentosByMenti(Long memberSeq, int limit, Long cursor) {
+        Long currentCursor = (cursor == null) ? Long.MAX_VALUE : cursor;
+
+        Slice<Reservation> reservationSlice = reservationRepository.findByMemberSeqWithSlice(
+                memberSeq, currentCursor, BaseStatus.ACTIVE, PageRequest.of(0, limit)
+        );
+
+        List<MyMentosByMentiResponse> content = reservationSlice.getContent().stream()
+                .map(MyMentosByMentiResponse::from)
+                .toList();
+
+        Long nextCursor = null;
+        if (!content.isEmpty()) {
+            Reservation lastReservation = reservationSlice.getContent().get(reservationSlice.getContent().size() - 1);
+            nextCursor = lastReservation.getReservationSeq();
+        }
+
+        return MyMentosByMentiSliceResponse.builder()
+                .content(content)
+                .nextCursor(nextCursor)
+                .hasNext(reservationSlice.hasNext())
                 .build();
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- 멘티 유저로 로그인 시 마이페이지 기능 중 나의 멘토스 내역 조회 항목에서 비춰질 데이터 조회 기능 구현
- 무한 스크롤 형태로 3개씩 비춰질 예정임.
- 멘토스 제목, 이미지, 가격, 지역(법정동)과 더불어 진행 상태(ProgressStatus) 값이 '진행 전' 혹은 '진행 완료'로 나타남. 

## 🔑 변경 사항 (Key Changes)

- 멘티 기준 나의 멘토스 내역 조회를 위한 DTO인 'MyMentosByMentiResponse', 그리고 페이징 처리를 위한 DTO인 'MyMentosByMentiSliceResponse'를 신규 생성.
- ReservationRepository에서 특정 멘티의 멘토스 예약 목록을 조회하는 메서드 추가
- MyPageService와 MyPageServiceImpl에서 'getMyMentosByMenti' 메서드 추가
- MyPageController에 해당 메서드 추가 및 예외처리.

## 📝 리뷰 요구사항 (To Reviewers)

- 나의 멘토스 내역 조회 (멘티 기준) 테스트를 위해 더미데이터 추가 필요.
- 무한 스크롤과 "진행 전/완료" 상태를 제대로 테스트하기 위해 한 명의 멘티가 여러 개의 멘토스(멘토링)을 예약한 데이터가 필요함.
- 따라서 아래의 더미 데이터를 DB에 적용해 줄 것.

- 테스트에 필요한 카테고리, 멘토, 멘티 회원 추가
INSERT INTO category (category_seq, category_name, category_description, status, created_at, modified_at)
VALUES (1, 'IT/개발', 'IT 및 개발 관련 카테고리입니다.', 'ACTIVE', NOW(), NOW())
ON DUPLICATE KEY UPDATE category_name = 'IT/개발';

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at) VALUES
(1, 'mentee_user', 'password123', '박멘티', '010-1111-1111', 'MENTI', '1995-01-01', 'ACTIVE', NOW(), NOW()),
(2, 'mentor_user', 'password123', '김멘토', '010-2222-2222', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW())
AS new_values ON DUPLICATE KEY UPDATE member_id = new_values.member_id;

- 멘토(2)가 생성한 멘토스 게시글 15개 추가 
INSERT INTO mentos (mentos_seq, mentos_title, mentos_content, price, mentos_image, mentos_postcode, mentos_roadaddress, mentos_bname, keyword_one, keyword_two, keyword_three, status, member_seq, category_seq, created_at, modified_at) VALUES
(10, '페이징 테스트 10', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(11, '페이징 테스트 11', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(12, '페이징 테스트 12', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(13, '페이징 테스트 13', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(14, '페이징 테스트 14', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(15, '페이징 테스트 15', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(16, '페이징 테스트 16', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(17, '페이징 테스트 17', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(18, '페이징 테스트 18', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(19, '페이징 테스트 19', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(20, '페이징 테스트 20', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(21, '페이징 테스트 21', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(22, '페이징 테스트 22', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(23, '페이징 테스트 23', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW()),
(24, '페이징 테스트 24', '내용', 10000, 'img.jpg', '12345', '도로명주소', '법정동', '키워드1', '키워드2', '키워드3', 'ACTIVE', 2, 1, NOW(), NOW())
ON DUPLICATE KEY UPDATE mentos_title = VALUES(mentos_title);

- 멘티(1)가 위 멘토스들을 예약한 내역 15건 추가 (과거/미래 날짜 혼합)
INSERT INTO reservation (reservation_seq, status, mentos_at, mentos_seq, member_seq, created_at, modified_at) VALUES
(10, 'ACTIVE', '2024-01-01 10:00:00', 10, 1, NOW(), NOW()), -- 과거 (진행 완료)
(11, 'ACTIVE', '2024-01-02 10:00:00', 11, 1, NOW(), NOW()), -- 과거 (진행 완료)
(12, 'ACTIVE', '2025-12-01 10:00:00', 12, 1, NOW(), NOW()), -- 미래 (진행 전)
(13, 'ACTIVE', '2025-12-02 10:00:00', 13, 1, NOW(), NOW()), -- 미래 (진행 전)
(14, 'ACTIVE', '2024-02-01 10:00:00', 14, 1, NOW(), NOW()), -- 과거 (진행 완료)
(15, 'ACTIVE', '2025-12-03 10:00:00', 15, 1, NOW(), NOW()), -- 미래 (진행 전)
(16, 'ACTIVE', '2024-03-01 10:00:00', 16, 1, NOW(), NOW()), -- 과거 (진행 완료)
(17, 'ACTIVE', '2025-12-04 10:00:00', 17, 1, NOW(), NOW()), -- 미래 (진행 전)
(18, 'ACTIVE', '2024-04-01 10:00:00', 18, 1, NOW(), NOW()), -- 과거 (진행 완료)
(19, 'ACTIVE', '2025-12-05 10:00:00', 19, 1, NOW(), NOW()), -- 미래 (진행 전)
(20, 'ACTIVE', '2024-05-01 10:00:00', 20, 1, NOW(), NOW()), -- 과거 (진행 완료)
(21, 'ACTIVE', '2025-12-06 10:00:00', 21, 1, NOW(), NOW()), -- 미래 (진행 전)
(22, 'ACTIVE', '2024-06-01 10:00:00', 22, 1, NOW(), NOW()), -- 과거 (진행 완료)
(23, 'ACTIVE', '2025-12-07 10:00:00', 23, 1, NOW(), NOW()), -- 미래 (진행 전)
(24, 'ACTIVE', '2024-07-01 10:00:00', 24, 1, NOW(), NOW())  -- 과거 (진행 완료)
ON DUPLICATE KEY UPDATE status = VALUES(status);

select * from member;
select * from mentos;
select * from reservation;

## 확인 방법 
1. Postman을 열고 Get 요청 방식으로 먼저 'http://localhost:9999/mypage/my-mentos-list?limit=5' 주소로 Send한다.
2. 요청에 성공하면 결과값으로 limit 개수만큼의 데이터가 조회되는지 확인이 가능하다.
<img width="1793" height="906" alt="image" src="https://github.com/user-attachments/assets/f117d147-639e-4d61-a766-706450eab6cf" />

3. 다음으로 커서 값을 추가해 새롭게 Send한다. 'http://localhost:9999/mypage/my-mentos-list?limit=5&cursor=20' 경로로 Send.
4. 이렇게 되면 content 배열에 reservation_seq가 19 ~ 15인 5개의 예약 내역 확인이 가능하다.
<img width="1755" height="911" alt="image" src="https://github.com/user-attachments/assets/d48c7c2d-47e2-4f34-a0d3-aac084e857a1" />

5. 마지막 페이지 조회를 위해 'http://localhost:9999/mypage/my-mentos-list?limit=5&cursor=15' 경로로 설정해 Send한다.
6. 해당 결과로 마지막 데이터까지 조회되고, 더 이상의 페이지가 없기 때문에 hasNext = false 값으로 반환되는 것을 확인할 수 있다.
<img width="1768" height="904" alt="image" src="https://github.com/user-attachments/assets/9bc8e1e7-2fdf-424f-81da-be3e949c3a8f" />

