### PR TITLE
feat: 본인인증

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -39,6 +39,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     INVALID_MEMBER_ID(5001, HttpStatus.BAD_REQUEST.value(), "아이디가 올바르지 않습니다."),
     INVALID_PASSWORD(5002, HttpStatus.BAD_REQUEST.value(), "비밀번호가 올바르지 않습니다."),
     CANNOT_LOGIN(5003,HttpStatus.BAD_REQUEST.value(),"로그인에 실패했습니다."),
+    REALNAME_MISMATCH(5004, HttpStatus.BAD_REQUEST.value(), "실명인증 정보가 일치하지 않습니다."),
 
     /**
      * Report 관련 8000대

--- a/src/main/java/com/shinhanDS5gi/memento/config/WebConfig.java
+++ b/src/main/java/com/shinhanDS5gi/memento/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.shinhanDS5gi.memento.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+class WebConfig {
+    @Bean
+    // 외부 API 호출용 RestTemplate 생성
+    public RestTemplate restTemplate() { return new RestTemplate(); }
+}
+
+
+

--- a/src/main/java/com/shinhanDS5gi/memento/controller/IdVerificationController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/IdVerificationController.java
@@ -1,0 +1,64 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.exception.MentosException;
+import com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus;
+import com.shinhanDS5gi.memento.service.IdVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member/verifications")
+public class IdVerificationController {
+
+    private final IdVerificationService idverificationservice;
+    private final Map<String, Map<String,String>> store = new ConcurrentHashMap<>(); //요청데이터 임시 저장
+
+    // 1) 금융결제원 api 요청
+    @PostMapping("/request")
+    public Map<String, String> request(@RequestBody Map<String,String> body) {
+        // UUID.randomUUID(): 보안 토큰 생성 (CSRF 방지 & 요청/응답 매칭)
+        String state = UUID.randomUUID().toString().replace("-", "");
+        store.put(state, body); // 해당 state에 요청 데이터 임시 저장
+        return Map.of(
+                "state", state,
+                "authorizeUrl", idverificationservice.buildAuthorizeUrl(state)
+        );
+    }
+
+    // 2) 확인(콜백) API → GET /member/verifications?code=...&state=...
+    @GetMapping
+    public ResponseEntity<Map<String,Object>> confirm(@RequestParam String code, // 인가코드
+                                                      @RequestParam String state) { // 요청시 발급했던 state
+        Map<String,String> saved = store.remove(state); // 요청데이터 꺼내면서 제거
+        if (saved == null) { // 만료/위조 방지
+            return ResponseEntity.ok(Map.of("code", 410, "message", "세션만료 또는 잘못된 state")); // 상태 메시지 반환
+        }
+
+        String token = idverificationservice.exchangeToken(code); // 인가코드로 액세스 토큰 교환(목 구현)
+        String holderName = idverificationservice.realName(token, saved); // 실명조회 호출(목 구현)
+
+        if (holderName == null) { // 테스트 데이터 없거나 실패
+            return ResponseEntity.ok(Map.of("code", 202, "message", "실명조회 실패(테스트 데이터 없음)")); // 실패 응답
+        }
+
+        String userName = saved.get("name"); // 사용자가 입력한 이름
+        Boolean match = (userName == null) ? null : idverificationservice.nameMatches(holderName, userName); // 이름 일치 여부
+
+        if (Boolean.FALSE.equals(match)) {
+            // 이름 불일치 → 공통 예외 던지기
+            throw new MentosException(BaseExceptionResponseStatus.REALNAME_MISMATCH);
+        }
+
+        Map<String,Object> res = new LinkedHashMap<>();
+        res.put("code", 200);
+        res.put("message", match == null ? "실명조회 성공(비교 이름 없음)" : "본인인증 성공");
+        res.put("account_holder_name", holderName);
+        res.put("match", match);
+        return ResponseEntity.ok(res);
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/IdVerificationService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/IdVerificationService.java
@@ -1,0 +1,14 @@
+package com.shinhanDS5gi.memento.service;
+
+import java.util.Map;
+
+public interface IdVerificationService {
+    String buildAuthorizeUrl(String state); // 실명인증 동의 화면 uri 생성
+    String exchangeToken(String code);      // (지금은 Mock) 인가코드→액세스 토큰 교환
+    String realName(String accessToken, Map<String,String> in); // (지금은 Mock) 실명조회 호출(더미)
+
+    default boolean nameMatches(String apiName, String userName) { // 응답 이름과 사용자가 입력한 이름 비교
+        if (apiName == null || userName == null) return false;
+        return apiName.replaceAll("\\s+","").equalsIgnoreCase(userName.replaceAll("\\s+","")); // 공백 제거·대소문자 무시 비교
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/IdVerificationServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/IdVerificationServiceImpl.java
@@ -1,0 +1,48 @@
+package com.shinhanDS5gi.memento.service;
+
+import org.springframework.stereotype.Service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Service
+public class IdVerificationServiceImpl implements IdVerificationService {
+
+    // 데모용 더미(계좌-이름)
+    private static final Map<String, String> MOCK_ACCOUNTS = Map.of(
+            "12345678901234", "홍길동",
+            "22223333444455", "김철수",
+            "99998888777766", "이영희"
+    );
+
+    // Client ID
+    private static final String CLIENT_ID    = "bded8696-709a-442c-822c-1c109faa6514";
+    // 등록된 콜백 URL
+    private static final String REDIRECT_URI = "http://localhost:9999/member/verifications";
+
+    @Override
+    public String buildAuthorizeUrl(String state) { // 동의 화면 URL 조립
+        // scope는 공백 인코딩, redirect_uri도 인코딩
+        String scope = URLEncoder.encode("login inquiry transfer oob", StandardCharsets.UTF_8);
+        return "https://testapi.openbanking.or.kr/oauth/2.0/authorize"
+                + "?response_type=code"
+                + "&client_id=" + CLIENT_ID
+                + "&redirect_uri=" + URLEncoder.encode(REDIRECT_URI, StandardCharsets.UTF_8)
+                + "&scope=" + scope
+                + "&client_info=" + "test"
+                + "&state=" + state // CSRF 방지/세션 식별자
+                + "&auth_type=0";
+    }
+
+    @Override
+    public String exchangeToken(String code) { // 인가코드→토큰 교환 (목)
+        return "dummy_access_token_" + code; // 테스트용 토큰 문자열
+    }
+
+    @Override
+    public String realName(String accessToken, Map<String, String> in) { // 실명조회 (목)
+        String acc = in.get("account_num"); // body 키 이름과 일치해야 함
+        return MOCK_ACCOUNTS.getOrDefault(acc, null); // 테스트 계좌면 이름 반환, 아니면 null
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MyPageServiceImpl.java
@@ -1,6 +1,7 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.dto.MyProfileResponse;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;


### PR DESCRIPTION
## 요약 (Summary)
- [x] 작업 내용 요약
- 본인인증(실명인증) API 구현
- 금융결제원 API 연결

## 🔑 변경 사항 (Key Changes)
- `WebConfig` , `IdVerificationService`  , `IdVerificationServiceImpl` , `IdVerificationController` 생성
- `BaseExceptionResponseStatus` 예외 사항 추가 

## 📝 리뷰 요구사항 (To Reviewers)
- API대로 잘 구현하였는지
- response 가 잘 오는지 
- 실제로 금융결제원 본인 인증을 하려면 사업자 등록증이 필요하기에 지금은 mock 데이터를 넣었습니다. mock 데이터로 본인 인증이 잘 되는지->가짜로 넣은 데이터가 잘 확인하고 응답으로 들어오는지 확인 하는 걸로 만들었습니다. 

## 확인 방법 
POSTMAN에 POST 로 `http://localhost:9999/member/verifications/request` url 입력 
body에 row를 선택해서 아래 코드를 입력해줍니다.
```
{
  "bankCodeStd": "097",
  "account_num": "12345678901234",
  "rrn13": "900101",
  "name": "홍길동"
}
```
 send로 보내면 아래 사진 처럼 uri가 나옵니다. 
<img width="1528" height="959" alt="image" src="https://github.com/user-attachments/assets/10025801-6a1f-42cc-9cd9-672744c0bfee" />

uri를 크롬 같은 사이트에 넣어주면  아래 사진처럼 본인인증이 나옵니다. 
<img width="1893" height="943" alt="image" src="https://github.com/user-attachments/assets/c25ef908-7102-48b2-896b-ca91cc37565c" />

동의 다하고 sns로 받기로 하고 본인인증을 해주시고 계좌번호나 은행은 가짜로 아무거나 넣어주세요 ars전화인증까지 아무거나로 해주시면 아래처럼 응답요청이 뜹니다. 그러면 인증확인 된것 입니다. 
<img width="903" height="371" alt="image" src="https://github.com/user-attachments/assets/d24c2a91-0c20-49e6-8926-95801f1697a4" />




