### PR TITLE
feat : 멱등성을 필요로 하는 모든 POST method에 멱등키 중복 검사, Redis 저장 로직 구현 

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
@@ -54,10 +54,11 @@ public class AdminController {
     @PostMapping(value = "/reports", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<Void> createReport(
             @RequestPart("requestDto") CreateReportRequest requestDto,
-            @RequestPart("imageFile") MultipartFile imageFile
+            @RequestPart("imageFile") MultipartFile imageFile,
+            @RequestHeader("Idem-Key") String IdemKey
     ) throws IOException {
         Long currentMemberSeq = 1L;
-        reportService.createReport(currentMemberSeq, requestDto, imageFile);
+        reportService.createReport(currentMemberSeq, requestDto, imageFile, IdemKey);
         return new BaseResponse<>(SUCCESS, null);
     }
 

--- a/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
@@ -53,9 +53,10 @@ public class AuthController {
     @PostMapping(value = "/signup/mento", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<Void> signupMento(
             @RequestPart("requestDto") @Valid MentoSignupRequest requestDto,
-            @RequestPart(value = "imageFile", required = false) MultipartFile certImage
+            @RequestPart(value = "imageFile", required = false) MultipartFile certImage,
+            @RequestHeader("Idem-Key") String IdemKey
     ) throws IOException {
-        memberService.signupMento(requestDto, certImage);
+        memberService.signupMento(requestDto, certImage, IdemKey);
         return new BaseResponse<>(SUCCESS, null);
     }
 

--- a/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AuthController.java
@@ -63,8 +63,9 @@ public class AuthController {
 
     /* 회원가입 (멘티) */
     @PostMapping("/signup/menti")
-    public BaseResponse<Void> signupMenti(@RequestBody MentiSignupRequest requestDto) {
-        memberService.signupMenti(requestDto);
+    public BaseResponse<Void> signupMenti(@RequestBody MentiSignupRequest requestDto,
+                                          @RequestHeader("Idem-Key") String idemKey) {
+        memberService.signupMenti(requestDto, idemKey);
         return new BaseResponse<>(SUCCESS, null);
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
@@ -43,10 +43,11 @@ public class MentoController {
     @PostMapping(value = "/mento-certifications", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<Void> createMentoCertification(
             @RequestPart("requestDto") CreateMentoCertificationRequest requestDto,
-            @RequestPart("imageFile") MultipartFile imageFile) throws IOException {
+            @RequestPart("imageFile") MultipartFile imageFile,
+            @RequestHeader("Idem-Key") String idemKey) throws IOException {
 
         Long currentMemberSeq = 1L;
-        mentoCertificationService.createMentoCertification(currentMemberSeq, requestDto, imageFile);
+        mentoCertificationService.createMentoCertification(currentMemberSeq, requestDto, imageFile, idemKey);
 
         return new BaseResponse<>(SUCCESS, null);
     }
@@ -63,10 +64,11 @@ public class MentoController {
     /* 멘토 프로필 생성 */
     @PostMapping(value = "/mento-profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<Void> createMentoProfile(@RequestPart("requestDto") CreateMentoProfileRequest requestDto,
-                                                 @RequestPart("imageFile") MultipartFile imageFile) throws IOException {
+                                                 @RequestPart("imageFile") MultipartFile imageFile,
+                                                 @RequestHeader("Idem-Key") String idemKey) throws IOException {
 
         Long currentMemberSeq = 1L;
-        mentoProfileService.createMentoProfile(currentMemberSeq, requestDto, imageFile);
+        mentoProfileService.createMentoProfile(currentMemberSeq, requestDto, imageFile, idemKey);
 
         return new BaseResponse<>(SUCCESS, null);
     }

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MyPageController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MyPageController.java
@@ -11,6 +11,7 @@ import com.shinhanDS5gi.memento.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
 
@@ -25,16 +26,16 @@ public class MyPageController {
 
     /* 리뷰 작성하기 */
     @PostMapping("/reviews")
-    public BaseResponse<Void> createReview(@RequestBody CreateReviewRequest requestDto) {
-        Long currentMemberSeq = 1L;
-        reviewService.createReview(currentMemberSeq, requestDto);
+    public BaseResponse<Void> createReview(@RequestBody CreateReviewRequest requestDto, @RequestHeader("Idem-Key") String idemKey) {
+        Long currentMemberSeq = 4L;
+        reviewService.createReview(currentMemberSeq, requestDto, idemKey);
         return new BaseResponse<>(SUCCESS, null);
     }
 
     /* 나의 프로필 조회하기 */
     @GetMapping("/profile")
     public BaseResponse<MyProfileResponse> getMyProfile() {
-        Long currentMemberSeq = 2L;
+        Long currentMemberSeq = 1L;
         MyProfileResponse profile = myPageService.getMyProfile(currentMemberSeq);
         return new BaseResponse<>(SUCCESS, profile);
     }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
@@ -25,7 +25,7 @@ public interface MemberService {
     void logout(Long memberSeq);
   
     //회원가입 멘토
-    void signupMento (MentoSignupRequest req, MultipartFile certImage)throws IOException;
+    void signupMento (MentoSignupRequest req, MultipartFile certImage, String idemKey)throws IOException;
 
     //회원가입 멘티
     void signupMenti (MentiSignupRequest req);

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberService.java
@@ -25,10 +25,10 @@ public interface MemberService {
     void logout(Long memberSeq);
   
     //회원가입 멘토
-    void signupMento (MentoSignupRequest req, MultipartFile certImage, String idemKey)throws IOException;
+    void signupMento (MentoSignupRequest req, MultipartFile certImage, String idemKey) throws IOException;
 
     //회원가입 멘티
-    void signupMenti (MentiSignupRequest req);
+    void signupMenti (MentiSignupRequest req, String idemKey);
 
     //제명하기
     void expelMemberByAdmin(Long memberSeq);

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
@@ -46,6 +46,7 @@ public class MemberServiceImpl implements MemberService {
     private final ReservationRepository reservationRepository;
     private final PaymentRepository paymentRepository;
     private final MentoCertificationService mentoCertificationService;
+    private final IdempotencyService idempotencyService;
 
     /* 관리자 페이지 전체 회원 조회하기 */
     @Override
@@ -138,7 +139,11 @@ public class MemberServiceImpl implements MemberService {
     /* 멘토 회원가입 */
     @Override
     @Transactional
-    public void signupMento(MentoSignupRequest req, @Nullable MultipartFile certImage) throws IOException {
+    public void signupMento(MentoSignupRequest req, @Nullable MultipartFile certImage, String idemKey) throws IOException {
+        // 멱등키 중복 여부 (추가)
+        if (idempotencyService.isDuplicate(idemKey)) {
+            throw new MemberException(ALREADY_SUCCESS_REQUEST);
+        }
 
         // 1) 중복 아이디 체크
         if (memberRepo.existsByMemberId(req.getMemberId())) {
@@ -157,19 +162,21 @@ public class MemberServiceImpl implements MemberService {
                 .memberType(MemberType.MENTO)
                 .status(BaseStatus.ACTIVE)
                 .build();
-        memberRepo.save(member);
-
+        Member savedMember = memberRepo.save(member);
 
         // 4) 자격증 저장
         if (req.getCertificationName() != null && !req.getCertificationName().isBlank()) {
             CreateMentoCertificationRequest certReq = CreateMentoCertificationRequest.builder()
                     .name(req.getCertificationName())
                     .build();
-            mentoCertificationService.createMentoCertification(member.getMemberSeq(), certReq, certImage);
+            mentoCertificationService.createMentoCertification(member.getMemberSeq(), certReq, certImage, idemKey);
             log.info("[signupMento] 자격증 등록 완료: {}", req.getCertificationName());
         } else {
             log.info("[signupMento] 자격증 없이 가입 완료");
         }
+
+        // 멱등키 Redis 저장
+        idempotencyService.saveKey(idemKey, String.valueOf(savedMember.getMemberSeq()));
     }
 
     /* 멘티 회원가입 */

--- a/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MemberServiceImpl.java
@@ -182,7 +182,12 @@ public class MemberServiceImpl implements MemberService {
     /* 멘티 회원가입 */
     @Override
     @Transactional
-    public void signupMenti(MentiSignupRequest req) {
+    public void signupMenti(MentiSignupRequest req, String idemKey) {
+        // 멱등키 중복 검사
+        if (idempotencyService.isDuplicate(idemKey)) {
+            throw new MemberException(ALREADY_SUCCESS_REQUEST);
+        }
+
         // 1) 중복 아이디 체크
         if (memberRepo.existsByMemberId(req.getMemberId())) {
             log.warn("[signupMenti] 중복 아이디: {}", req.getMemberId());
@@ -201,10 +206,11 @@ public class MemberServiceImpl implements MemberService {
                 .status(BaseStatus.ACTIVE)
                 .build();
 
-        memberRepo.save(m);
+        Member savedMember = memberRepo.save(m);
+
+        // 멱등키 Redis 저장
+        idempotencyService.saveKey(idemKey, String.valueOf(savedMember.getMemberSeq()));
     }
-
-
 
     /* 회원 제명하기 (관리자) */
     @Transactional

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationService.java
@@ -13,5 +13,5 @@ public interface MentoCertificationService {
     List<MentoCertificationsResponse> getMentoCertifications(Long memberSeq);
 
     /* 내 자격증 추가 */
-    void createMentoCertification(Long memberSeq, CreateMentoCertificationRequest requestDto, MultipartFile imageFile) throws IOException;
+    void createMentoCertification(Long memberSeq, CreateMentoCertificationRequest requestDto, MultipartFile imageFile, String idemKey) throws IOException;
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoCertificationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.common.exception.MemberException;
+import com.shinhanDS5gi.memento.common.exception.MentoCertificationException;
 import com.shinhanDS5gi.memento.config.S3Uploader;
 import com.shinhanDS5gi.memento.domain.MentoCertification;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
@@ -19,8 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.CANNOT_FOUND_MEMBER;
-import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.NOT_A_MENTO;
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +30,7 @@ public class MentoCertificationServiceImpl implements MentoCertificationService 
     private final MemberRepository memberRepository;
     private final MentoCertificationRepository mentoCertificationRepository;
     private final S3Uploader s3Uploader;
+    private final IdempotencyService idempotencyService;
 
     /* 내 보유 자격증 목록 조회 */
     @Override
@@ -48,7 +49,12 @@ public class MentoCertificationServiceImpl implements MentoCertificationService 
     /* 내 자격증 추가 */
     @Override
     @Transactional
-    public void createMentoCertification(Long memberSeq, CreateMentoCertificationRequest requestDto, MultipartFile imageFile) throws IOException {
+    public void createMentoCertification(Long memberSeq, CreateMentoCertificationRequest requestDto, MultipartFile imageFile, String idemKey) throws IOException {
+
+        if (idempotencyService.isDuplicate(idemKey)) {
+            throw new MentoCertificationException(ALREADY_SUCCESS_REQUEST);
+        }
+
         Member member = memberRepository.findByMemberSeqAndStatus(memberSeq, BaseStatus.ACTIVE)
                 .orElseThrow(() -> new MemberException(CANNOT_FOUND_MEMBER));
 
@@ -71,6 +77,9 @@ public class MentoCertificationServiceImpl implements MentoCertificationService 
                 BaseStatus.ACTIVE,
                 member
         );
-        mentoCertificationRepository.save(certification);
+        MentoCertification savedCertification = mentoCertificationRepository.save(certification);
+
+        // 멱등키 저장
+        idempotencyService.saveKey(idemKey, String.valueOf(savedCertification.getMentoCertificationSeq()));
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 public interface MentoProfileService {
 
     /* 신규 멘토 프로필 생성 */
-    void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto, MultipartFile imageFile) throws IOException;
+    void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto, MultipartFile imageFile, String idemKey) throws IOException;
 
     /* 멘토 프로필 수정 */
     void updateMentoProfile(Long memberSeq, UpdateMentoProfileRequest requestDto, MultipartFile imageFile) throws IOException;

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
@@ -1,6 +1,5 @@
 package com.shinhanDS5gi.memento.service;
 
-import com.shinhanDS5gi.memento.common.exception.MentoCertificationException;
 import com.shinhanDS5gi.memento.common.exception.MentoProfileException;
 import com.shinhanDS5gi.memento.common.exception.MemberException;
 import com.shinhanDS5gi.memento.config.S3Uploader;

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
@@ -1,5 +1,6 @@
 package com.shinhanDS5gi.memento.service;
 
+import com.shinhanDS5gi.memento.common.exception.MentoCertificationException;
 import com.shinhanDS5gi.memento.common.exception.MentoProfileException;
 import com.shinhanDS5gi.memento.common.exception.MemberException;
 import com.shinhanDS5gi.memento.config.S3Uploader;
@@ -28,11 +29,16 @@ public class MentoProfileServiceImpl implements MentoProfileService {
     private final MentoProfileRepository mentoProfileRepository;
     private final MemberRepository memberRepository;
     private final S3Uploader s3Uploader;
+    private final IdempotencyService idempotencyService;
 
     /* 멘토 프로필 생성 */
     @Override
     @Transactional
-    public void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto, MultipartFile imageFile) throws IOException {
+    public void createMentoProfile(Long memberSeq, CreateMentoProfileRequest requestDto, MultipartFile imageFile, String idemKey) throws IOException {
+
+        if (idempotencyService.isDuplicate(idemKey)) {
+            throw new MentoProfileException(ALREADY_SUCCESS_REQUEST);
+        }
 
         /* 회원 가입한 사용자인가? */
         Member member = memberRepository.findByMemberSeqAndStatus(memberSeq, BaseStatus.ACTIVE)
@@ -51,7 +57,10 @@ public class MentoProfileServiceImpl implements MentoProfileService {
         String imageUrl = s3Uploader.upload(imageFile);
 
         MentoProfile mentoProfile = requestDto.toEntity(member, imageUrl);
-        mentoProfileRepository.save(mentoProfile);
+        MentoProfile savedProfile = mentoProfileRepository.save(mentoProfile);
+
+        // 멱등키 저장
+        idempotencyService.saveKey(idemKey, String.valueOf(savedProfile.getMentoProfileSeq()));
     }
 
     /* 멘토 프로필 수정 */

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -182,16 +182,16 @@ public class MentosServiceImpl implements MentosService {
             Category category = categoryRepository.findByCategorySeqAndStatus(createMentosRequest.getCategorySeq(), BaseStatus.ACTIVE)
                     .orElseThrow(() -> new CategoryException(CANNOT_FOUND_CATEGORY));
 
-            // s3 에 업로드된 url 로 db 에 저장하기
-            String uploadedMentosImage = s3Uploader.upload(createMentosRequest.getMentosImage());
-            Mentos mentos = new Mentos(createMentosRequest.getMentosTitle(), createMentosRequest.getMentosContent(), createMentosRequest.getPrice(), uploadedMentosImage, createMentosRequest.getMentosPostcode(),
-                    createMentosRequest.getMentosRoadaddress(), createMentosRequest.getMentosBname(), createMentosRequest.getMentosDetail(), category, member, BaseStatus.ACTIVE);
-
-            Mentos createdMentos = mentosRepository.save(mentos);
-            if(idempotencyService.isDuplicate(idemKey)){
+            if (idempotencyService.isDuplicate(idemKey)) {
                 log.info("[MentosServiceImpl.createMentos...멘토스 생성 이미 완료...동일한 요청]");
                 throw new MentosException(ALREADY_SUCCESS_REQUEST);
-            }else{
+            } else {
+                // s3 에 업로드된 url 로 db 에 저장하기
+                String uploadedMentosImage = s3Uploader.upload(createMentosRequest.getMentosImage());
+                Mentos mentos = new Mentos(createMentosRequest.getMentosTitle(), createMentosRequest.getMentosContent(), createMentosRequest.getPrice(), uploadedMentosImage, createMentosRequest.getMentosPostcode(),
+                        createMentosRequest.getMentosRoadaddress(), createMentosRequest.getMentosBname(), createMentosRequest.getMentosDetail(), category, member, BaseStatus.ACTIVE);
+
+                Mentos createdMentos = mentosRepository.save(mentos);
                 log.info("[MentosServiceImpl.createMentos...멘토스 생성 완료]");
                 idempotencyService.saveKey(idemKey, String.valueOf(createdMentos.getMentosSeq()));
             }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
@@ -16,7 +16,7 @@ public interface ReportService {
     void approveReport(Long reportSeq);
 
     /* 신규 신고 작성 */
-    void createReport(Long memberSeq, CreateReportRequest requestDto, MultipartFile imageFile) throws IOException;
+    void createReport(Long memberSeq, CreateReportRequest requestDto, MultipartFile imageFile, String IdemKey) throws IOException;
 
     /* 모든 신고 내역 조회 */
     List<SelectReportResponse> findAllReports();

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -38,6 +38,7 @@ public class ReportServiceImpl implements ReportService {
     private final MentosRepository mentosRepository;
     private final MemberService memberService;
     private final S3Uploader s3Uploader;
+    private final IdempotencyService idempotencyService;
 
     /* 신고 거부 하기 */
     @Override
@@ -83,7 +84,12 @@ public class ReportServiceImpl implements ReportService {
     /* 신고 작성하기 */
     @Override
     @Transactional
-    public void createReport(Long memberSeq, CreateReportRequest requestDto, MultipartFile imageFile) throws IOException {
+    public void createReport(Long memberSeq, CreateReportRequest requestDto, MultipartFile imageFile, String idemKey) throws IOException {
+        // 멱등키 중복 여부
+        if (idempotencyService.isDuplicate(idemKey)){
+            throw new ReportException(ALREADY_SUCCESS_REQUEST);
+        }
+
         Member reporter = memberRepository.findByMemberSeqAndStatus(memberSeq, BaseStatus.ACTIVE)
                 .orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
         Mentos reportedMentos = mentosRepository.findByMentosSeqAndStatus(requestDto.getMentosSeq(), BaseStatus.ACTIVE)
@@ -99,7 +105,10 @@ public class ReportServiceImpl implements ReportService {
         String imageUrl = s3Uploader.upload(imageFile); // 파일 업로드하고 URL 반환받기
 
         Report report = requestDto.toEntity(reporter, reportedMentos, imageUrl);
-        reportRepository.save(report);
+        Report savedReport = reportRepository.save(report);
+
+        // 멱등키 Redis 저장
+        idempotencyService.saveKey(idemKey, String.valueOf(savedReport.getReportSeq()));
     }
 
     /* 모든 신고 내역 조회 */

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReviewService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReviewService.java
@@ -12,5 +12,5 @@ public interface ReviewService {
 
     /* 리뷰 작성하기 */
     @Transactional
-    void createReview(Long memberSeq, CreateReviewRequest requestDTO);
+    void createReview(Long memberSeq, CreateReviewRequest requestDTO, String idemKey);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
@@ -33,6 +33,7 @@ public class ReviewServiceImpl implements ReviewService {
     private final MemberRepository memberRepository;
     private final MentosRepository mentosRepository;
     private final ReservationRepository reservationRepository;
+    private final IdempotencyService idempotencyService;
 
     /* 멘토 리뷰 조회하기 */
     @Override
@@ -67,7 +68,13 @@ public class ReviewServiceImpl implements ReviewService {
     /* 리뷰 작성하기 */
     @Transactional
     @Override
-    public void createReview(Long memberSeq, CreateReviewRequest requestDto) {
+    public void createReview(Long memberSeq, CreateReviewRequest requestDto, String idemKey) {
+
+        // 멱등키 중복 여부 검사
+        if (idempotencyService.isDuplicate(idemKey)) {
+            throw new ReviewException(ALREADY_SUCCESS_REQUEST);
+        }
+
         /* 리뷰 작성자(유저), 리뷰 대상(멘토스) 조회 */
         Member reviewer = memberRepository.findByMemberSeqAndStatus(memberSeq, BaseStatus.ACTIVE)
                 .orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
@@ -89,6 +96,9 @@ public class ReviewServiceImpl implements ReviewService {
         }
 
         Review review = requestDto.toEntity(reviewer, reviewedMentos);
-        reviewRepository.save(review);
+        Review savedReview = reviewRepository.save(review);
+
+        // 멱등키 저장
+        idempotencyService.saveKey(idemKey, String.valueOf(savedReview.getReviewSeq()));
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- 중복 요청을 방지하기 위해 멱등 키 컴포넌트 생성 및 필요한 메서드에 적용
- POST 메서드 (신고 작성하기, 회원가입(멘토), 회원가입(멘티), 리뷰 작성하기) 항목에 멱등키 컴포넌트 적용 및 코드 변경

## 🔑 변경 사항 (Key Changes)

- POST 메서드 관련 Controller, Service, ServiceImpl 코드 수정 (IdempotencyService 이용 멱등키 컴포넌트 연결)

## 📝 리뷰 요구사항 (To Reviewers)

- Redis 실행 후, 앞서 언급한 POST 메서드를 postman을 통해 각 URL에 맞게 Send함.
- 대표로 '리뷰 작성하기' 테스트를 진행 예정이고, 다른 메서드도 동일 적용했으니 참고 바람.
- 더미 데이터
```
-- ------------------------------------------------------------------
-- 1. (필수) 테스트에 필요한 기본 데이터 생성 (카테고리, 멘토, 멘티들)
-- ------------------------------------------------------------------
INSERT INTO category (category_seq, category_name, category_description, status, created_at, modified_at)
VALUES (1, 'IT/개발', 'IT 및 개발 관련 카테고리입니다.', 'ACTIVE', NOW(), NOW())
ON DUPLICATE KEY UPDATE category_name = 'IT/개발';

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at) VALUES
(1, 'mentor_user', 'password123', '김멘토', '010-1111-1111', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW()),
(4, 'mentee_user3', 'password123', '최멘티', '010-4444-4444', 'MENTI', '2000-01-01', 'ACTIVE', NOW(), NOW())
ON DUPLICATE KEY UPDATE member_id = VALUES(member_id);

-- ------------------------------------------------------------------
-- 2. (필수) 김멘토(1)가 작성한, 리뷰 대상 멘토링 게시글 생성
-- ------------------------------------------------------------------
INSERT INTO mentos (mentos_seq, mentos_title, mentos_content, price, mentos_image, mentos_postcode, mentos_roadaddress, mentos_bname, mentos_detail, status, member_seq, category_seq, created_at, modified_at) VALUES
(2, 'Spring 심화 멘토링', '스프링 심화 과정입니다.', 20000, 'spring.jpg', '456', '주소', '서초동', '상세', 'ACTIVE', 1, 1, NOW(), NOW())
ON DUPLICATE KEY UPDATE mentos_title = 'Spring 심화 멘토링';

-- ------------------------------------------------------------------
-- 3. (필수) 최멘티(4)가 '과거에' 멘토링을 수강 완료한 예약 내역 추가
-- ------------------------------------------------------------------
INSERT INTO reservation (reservation_seq, status, mentos_at, mentos_seq, member_seq, created_at, modified_at) VALUES
(3, 'ACTIVE', '2024-02-01 10:00:00', 2, 4, NOW(), NOW())
ON DUPLICATE KEY UPDATE status = 'ACTIVE';

select * from member;
select * from mentos;
select * from review;

-- 최멘티(member_seq=4)가 Spring 심화 멘토링(mentos_seq=2)에 작성했던 리뷰를 삭제합니다.
DELETE FROM review WHERE member_seq = 4 AND mentos_seq = 2;
```

## 확인 방법 
1. Postman을 열고 POST 방식으로 'http://localhost:9999/mypage/reviews' 경로로 설정
2. Body-raw-JSON 선택 후 아래 json 문 삽입.
```
{
  "mentosSeq": 2, 
  "reviewRating": 5,
  "reviewContent": "Spring에 대해 자신감이 생겼어요!"
}
```
3. Header 선택 후 Key 값에 Idem-Key, Value 값에 {{$guid}} 삽입.
4. Send 요청 후 요청에 성공했다는 메시지 확인.
<img width="1467" height="572" alt="image" src="https://github.com/user-attachments/assets/5591ac6a-17e0-4911-8169-7d8429b79620" />

5. Redis CLI 창에서 아래와 같은 형태로 멱등키 값 검색.

5-1. 처음에 KEYS * 입력 -> empty list인지 확인.

5-2. Send 요청 후 다시 KEYS * 입력 -> 멱등키 값이 발급되었는지 확인.

5-3. TTL '멱등키값' -> 몇 초 남았는지 확인 (default 30초에서 시작)

5-4. GET '멱등키값' -> 어떤 Seq를 대상으로 하는지 확인. 

5-5. 30초 후 KEYS * -> 발급된 키가 초기화 되었는지 확인. 

![멱등키](https://github.com/user-attachments/assets/eaed851a-f4eb-41ad-984d-005acfcf1cd5)
