### PR TITLE
feat : 멘토 멘티 간 채팅 기능 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,12 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+    // Websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     //비밀번호 해시
     implementation 'org.springframework.security:spring-security-crypto'
 

--- a/src/main/java/com/shinhanDS5gi/memento/config/WebSocketConfig.java
+++ b/src/main/java/com/shinhanDS5gi/memento/config/WebSocketConfig.java
@@ -1,0 +1,31 @@
+package com.shinhanDS5gi.memento.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker // STOMP를 사용하는 WebSocket 메시지 브로커를 활성화
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 클라이언트가 WebSocket에 연결하기 위한 엔드포인트를 설정
+        registry.addEndpoint("/ws/chat") // 이 주소로 연결
+                .setAllowedOriginPatterns("*") // 모든 도메인에서 접속 허용
+                .withSockJS(); // SockJS 지원을 활성화하여 오래된 브라우저 호환성 제공
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 메시지 브로커가 /topic으로 시작하는 주소를 구독하는 클라이언트에게 메시지를 전달하도록 설정
+        // 클라이언트는 이 주소를 구독(subscribe)하고 있어야 메시지를 받을 수 있음.
+        registry.enableSimpleBroker("/topic");
+
+        // 클라이언트가 서버로 메시지를 보낼 때 사용할 주소의 접두사를 설정
+        // 예: client.send("/app/chat/send", ...)
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/controller/ChattingController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/ChattingController.java
@@ -1,0 +1,54 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.dto.chat.ChattingMessageRequest;
+import com.shinhanDS5gi.memento.dto.chat.ChattingMessageResponse;
+import com.shinhanDS5gi.memento.dto.chat.ChattingRoomDetailResponse;
+import com.shinhanDS5gi.memento.service.ChattingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@Controller
+@RequiredArgsConstructor
+public class ChattingController {
+
+    private final SimpMessageSendingOperations messagingTemplate;
+    private final ChattingService chattingService;
+
+    /* 실시간 메시지 전송 처리 */
+    @MessageMapping("/chat/send")
+    public void sendMessage(ChattingMessageRequest messageDto) {
+
+        // 서비스에 메시지를 전달해 DB에 저장 및 응답
+        ChattingMessageResponse responseDto = chattingService.processAndSaveMessage(messageDto);
+
+        // 메시지 브로커를 통해 해당 채팅방을 구독하는 모든 클라이언트에게 메시지 전송
+        messagingTemplate.convertAndSend("/topic/chat/room/" + responseDto.getChattingRoomSeq(), responseDto);
+    }
+
+    /* 채팅방 상세 정보와 이전 대화 내역 조회 */
+    @GetMapping("/api/chat/rooms/{chattingRoomSeq}/messages")
+    @ResponseBody
+    public BaseResponse<ChattingRoomDetailResponse> getChattingRoomDetails(@PathVariable Long chattingRoomSeq) {
+        Long currentMemberSeq = 1L; // 임시 사용자 ID (실제로는 SecurityContext에서 가져와야 함)
+        ChattingRoomDetailResponse details = chattingService.getChattingRoomDetails(chattingRoomSeq, currentMemberSeq);
+        return new BaseResponse<>(SUCCESS, details);
+    }
+
+    /* 특정 채팅방 메시지 모두 읽음 처리 (채팅방 입장 시점) */
+    @PatchMapping("/api/chat/rooms/{chattingRoomSeq}/read")
+    @ResponseBody
+    public BaseResponse<Void> markAsRead(@PathVariable Long chattingRoomSeq) {
+        Long currentMemberSeq = 1L;
+        chattingService.markAsRead(chattingRoomSeq, currentMemberSeq);
+        return new BaseResponse<>(SUCCESS, null);
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/controller/PaymentController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/PaymentController.java
@@ -1,0 +1,30 @@
+package com.shinhanDS5gi.memento.controller;
+
+import com.shinhanDS5gi.memento.common.response.BaseResponse;
+import com.shinhanDS5gi.memento.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    /**
+     * (테스트용 임시 API)
+     * 특정 결제를 완료 처리하고 채팅방을 생성합니다.
+     * @param paymentId 결제 ID
+     */
+    @PostMapping("/{paymentId}/complete")
+    public BaseResponse<Void> completePaymentAndCreateChatRoom(@PathVariable Long paymentId) {
+        paymentService.processPaymentCompletion(paymentId);
+        return new BaseResponse<>(SUCCESS, null);
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/domain/chat/ChattingMessageDocument.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/chat/ChattingMessageDocument.java
@@ -1,0 +1,24 @@
+package com.shinhanDS5gi.memento.domain.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Document(collection = "chat_messages") // MongoDB의 chat_messages 컬렉션에 매핑
+public class ChattingMessageDocument {
+
+    @Id
+    private String id; // MongoDB의 고유 ID
+
+    private Long chattingRoomSeq;
+    private Long senderSeq;
+    private String senderName;
+    private String senderProfileImage;
+    private String message;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/shinhanDS5gi/memento/domain/chat/ChattingParticipant.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/chat/ChattingParticipant.java
@@ -1,0 +1,60 @@
+package com.shinhanDS5gi.memento.domain.chat;
+
+import com.shinhanDS5gi.memento.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class) // updatedAt 자동 업데이트를 위해 추가
+@Table(name = "chatting_participant")
+public class ChattingParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chatting_participant_seq")
+    private Long chattingParticipantSeq;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chatting_room_seq", nullable = false)
+    private ChattingRoom chattingRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_seq", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private boolean hasUnreadMessage;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    // 생성자
+    public ChattingParticipant(ChattingRoom room, Member member) {
+        this.chattingRoom = room;
+        this.member = member;
+        this.hasUnreadMessage = false; // 처음에는 안 읽은 메시지 없음이 default
+    }
+
+    // 비즈니스 로직
+    public void markAsRead() {
+        this.hasUnreadMessage = false;
+    }
+
+    public void markAsUnread() {
+        this.hasUnreadMessage = true;
+    }
+
+    // 연관관계 편의 메서드 (내부 사용)
+    protected void setChattingRoom(ChattingRoom room) {
+        this.chattingRoom = room;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/domain/chat/ChattingRoom.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/chat/ChattingRoom.java
@@ -1,0 +1,64 @@
+package com.shinhanDS5gi.memento.domain.chat;
+
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import com.shinhanDS5gi.memento.domain.base.BaseTime;
+import com.shinhanDS5gi.memento.domain.payment.Payment;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 기본 생성자 보호
+@Table(name = "chatting_room")
+public class ChattingRoom extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chatting_room_seq")
+    private Long chattingRoomSeq;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_seq", unique = true, nullable = false)
+    private Payment payment;
+
+    @Column(length = 500)
+    private String lastMessage;
+
+    private LocalDateTime lastMessageAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BaseStatus status;
+
+    @OneToMany(mappedBy = "chattingRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChattingParticipant> participants = new ArrayList<>();
+
+    // 생성 메서드
+    public static ChattingRoom create(Payment payment) {
+        ChattingRoom room = new ChattingRoom();
+        room.payment = payment;
+        room.status = BaseStatus.ACTIVE;
+        // 멘토와 멘티를 참여자로 추가
+        room.addParticipant(new ChattingParticipant(room, payment.getMember())); // 멘티
+        room.addParticipant(new ChattingParticipant(room, payment.getReservation().getMentos().getMember())); // 멘토
+        return room;
+    }
+
+    // 연관관계 편의 메서드
+    private void addParticipant(ChattingParticipant participant) {
+        this.participants.add(participant);
+        participant.setChattingRoom(this); // 양방향 연관관계 설정
+    }
+
+    // 비즈니스 로직
+    public void updateLastMessage(String message, LocalDateTime sentAt) {
+        this.lastMessage = message;
+        this.lastMessageAt = sentAt;
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingMessageRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingMessageRequest.java
@@ -1,0 +1,13 @@
+package com.shinhanDS5gi.memento.dto.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 클라이언트가 서버로 메시지를 보낼 때 사용하는 DTO
+@Getter
+@NoArgsConstructor
+public class ChattingMessageRequest {
+    private Long chattingRoomSeq; // 채팅방
+    private Long senderSeq;       // 보내는 사람
+    private String message;
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingMessageResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingMessageResponse.java
@@ -1,0 +1,19 @@
+package com.shinhanDS5gi.memento.dto.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 서버가 클라이언트로 메시지를 보낼 때 사용하는 DTO
+@Getter
+@Builder
+public class ChattingMessageResponse {
+
+    private Long chattingRoomSeq;
+    private Long senderSeq;
+    private String senderName;          // 보내는 사람
+    private String senderProfileImage;  // 프로필 사진
+    private String message;
+    private LocalDateTime sentAt;       // 보낸 시간
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingRoomDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingRoomDetailResponse.java
@@ -1,0 +1,23 @@
+package com.shinhanDS5gi.memento.dto.chat;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+    @Getter
+    @Builder
+    public class ChattingRoomDetailResponse {
+
+        private Long chattingRoomSeq;
+        private String mentosTitle;
+        private List<ParticipantInfo> participants;     // 참여자 정보 목록 (이름, 프사)
+        private List<ChattingMessageResponse> messages; // 과거 메시지 목록 (대화 내용)
+
+        @Getter
+        @Builder
+        public static class ParticipantInfo {
+            private Long memberSeq;
+            private String memberName;
+            private String profileImage;
+        }
+    }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingRoomListByMentosResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/chat/ChattingRoomListByMentosResponse.java
@@ -1,0 +1,56 @@
+package com.shinhanDS5gi.memento.dto.chat;
+
+import com.shinhanDS5gi.memento.domain.chat.ChattingParticipant;
+import com.shinhanDS5gi.memento.domain.chat.ChattingRoom;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/* 멘토의 채팅방 목록을 멘토스별로 그룹화하여 반환하기 위한 응답 DTO */
+@Getter
+public class ChattingRoomListByMentosResponse {
+
+    private final Long mentosId;
+    private final String mentosTitle;
+    private final List<ChatRoomInfo> chatRooms;
+
+    public ChattingRoomListByMentosResponse(Long mentosId, String mentosTitle, List<ChattingRoom> rooms, Long mentorId) {
+        this.mentosId = mentosId;
+        this.mentosTitle = mentosTitle;
+        this.chatRooms = rooms.stream()
+                .map(room -> new ChatRoomInfo(room, mentorId))
+                .collect(Collectors.toList());
+    }
+
+    /* 개별 채팅방의 상세 정보를 담는 내부 DTO */
+    @Getter
+    public static class ChatRoomInfo {
+        private final Long chatRoomId;
+        private final String mentiName;
+        private final String lastMessage;
+        private final LocalDateTime lastMessageAt;
+        private final boolean hasUnreadMessage;
+
+        public ChatRoomInfo(ChattingRoom room, Long mentorId) {
+            this.chatRoomId = room.getChattingRoomSeq();
+
+            ChattingParticipant mentiParticipant = room.getParticipants().stream()
+                    .filter(p -> !p.getMember().getMemberSeq().equals(mentorId))
+                    .findFirst()
+                    .orElseThrow();
+
+            this.mentiName = mentiParticipant.getMember().getMemberName();
+            this.lastMessage = room.getLastMessage();
+            this.lastMessageAt = room.getLastMessageAt();
+
+            ChattingParticipant mentorParticipant = room.getParticipants().stream()
+                    .filter(p -> p.getMember().getMemberSeq().equals(mentorId))
+                    .findFirst()
+                    .orElseThrow();
+            this.hasUnreadMessage = mentorParticipant.isHasUnreadMessage();
+        }
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/chat/ChattingMessageRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/chat/ChattingMessageRepository.java
@@ -1,0 +1,11 @@
+package com.shinhanDS5gi.memento.repository.chat;
+
+import com.shinhanDS5gi.memento.domain.chat.ChattingMessageDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface ChattingMessageRepository extends MongoRepository<ChattingMessageDocument, String> {
+    /* 채팅방 ID를 기준으로 모든 메시지를 시간 순으로 조회 */
+    List<ChattingMessageDocument> findByChattingRoomSeqOrderByCreatedAtAsc(Long chattingRoomSeq);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/chat/ChattingParticipantRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/chat/ChattingParticipantRepository.java
@@ -1,0 +1,15 @@
+package com.shinhanDS5gi.memento.repository.chat;
+
+import com.shinhanDS5gi.memento.domain.chat.ChattingParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChattingParticipantRepository extends JpaRepository<ChattingParticipant, Long> {
+
+    /* 특정 채팅방과 특정 사용자를 기준으로 참여 정보를 조회 */
+    Optional<ChattingParticipant> findByChattingRoom_ChattingRoomSeqAndMember_MemberSeq(Long chattingRoomSeq, Long memberSeq);
+
+    /* 채팅방 ID와 보낸 사람 ID를 제외하여 상대방을 찾는 메서드 */
+    Optional<ChattingParticipant> findByChattingRoom_ChattingRoomSeqAndMember_MemberSeqNot(Long chattingRoomSeq, Long senderSeq);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/chat/ChattingRoomRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/chat/ChattingRoomRepository.java
@@ -1,0 +1,30 @@
+package com.shinhanDS5gi.memento.repository.chat;
+
+import com.shinhanDS5gi.memento.domain.chat.ChattingRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Long> {
+
+    /* 멘토가 참여하고 있는 모든 채팅방을 마지막 메시지 시간 순서대로 정렬하여 조회 (채팅방 목록)*/
+    @Query("SELECT DISTINCT cr FROM ChattingRoom cr " +
+            "JOIN FETCH cr.participants p " +
+            "JOIN FETCH p.member " +
+            "JOIN FETCH cr.payment pay " +
+            "JOIN FETCH pay.reservation r " +
+            "JOIN FETCH r.mentos m " +
+            "WHERE m.member.memberSeq = :mentorSeq " +
+            "ORDER BY cr.lastMessageAt DESC")
+    List<ChattingRoom> findAllByMentorIdGroupedByMentos(@Param("mentorSeq") Long mentorSeq);
+
+    /* 채팅방 상세정보 조회 (채팅방 내부) */
+    @Query("SELECT cr FROM ChattingRoom cr " +
+            "JOIN FETCH cr.participants p " +
+            "JOIN FETCH p.member " +
+            "WHERE cr.chattingRoomSeq = :chattingRoomSeq")
+    Optional<ChattingRoom> findByIdWithParticipants(@Param("chattingRoomSeq") Long chattingRoomSeq);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/ChattingService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ChattingService.java
@@ -1,0 +1,22 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.dto.chat.ChattingMessageRequest;
+import com.shinhanDS5gi.memento.dto.chat.ChattingMessageResponse;
+import com.shinhanDS5gi.memento.dto.chat.ChattingRoomDetailResponse;
+import com.shinhanDS5gi.memento.dto.chat.ChattingRoomListByMentosResponse;
+import java.util.List;
+
+public interface ChattingService {
+
+    /* 멘토의 채팅방 목록을 멘토스 그룹 별로 조회 */
+    List<ChattingRoomListByMentosResponse> getChatRoomsByMentosForMentor(Long mentorId);
+
+    /* 클라이언트로부터 받은 채팅 메시지를 처리하고 저장 */
+    ChattingMessageResponse processAndSaveMessage(ChattingMessageRequest messageDto);
+
+    /* 특정 채팅방의 상세 정보와 이전 대화 메시지 내역 조회 */
+    ChattingRoomDetailResponse getChattingRoomDetails(Long chattingRoomSeq, Long currentMemberSeq);
+
+    /* 특정 채팅방의 메시지를 모두 읽음 처리 */
+    void markAsRead(Long chattingRoomSeq, Long memberSeq);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/ChattingServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ChattingServiceImpl.java
@@ -1,0 +1,165 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.domain.MentoProfile;
+import com.shinhanDS5gi.memento.domain.Mentos;
+import com.shinhanDS5gi.memento.domain.chat.ChattingMessageDocument;
+import com.shinhanDS5gi.memento.domain.chat.ChattingParticipant;
+import com.shinhanDS5gi.memento.domain.chat.ChattingRoom;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.domain.member.MemberType;
+import com.shinhanDS5gi.memento.dto.chat.ChattingMessageRequest;
+import com.shinhanDS5gi.memento.dto.chat.ChattingMessageResponse;
+import com.shinhanDS5gi.memento.dto.chat.ChattingRoomDetailResponse;
+import com.shinhanDS5gi.memento.dto.chat.ChattingRoomListByMentosResponse;
+import com.shinhanDS5gi.memento.repository.MentoProfileRepository;
+import com.shinhanDS5gi.memento.repository.chat.ChattingMessageRepository;
+import com.shinhanDS5gi.memento.repository.chat.ChattingParticipantRepository;
+import com.shinhanDS5gi.memento.repository.chat.ChattingRoomRepository;
+import com.shinhanDS5gi.memento.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChattingServiceImpl implements ChattingService {
+
+    private final ChattingMessageRepository chattingMessageRepository;
+    private final ChattingRoomRepository chattingRoomRepository;
+    private final ChattingParticipantRepository chattingParticipantRepository;
+    private final MemberRepository memberRepository;
+    private final MentoProfileRepository mentoProfileRepository;
+
+    // 멘티 고정 프로필 이미지 (무슨 사진 넣을지 논의 필요)
+    private static final String MENTI_DEFAULT_IMAGE = "";
+
+    @Transactional
+    public ChattingMessageResponse processAndSaveMessage(ChattingMessageRequest messageDto) {
+        Member sender = memberRepository.findById(messageDto.getSenderSeq())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        String profileImage = getProfileImage(sender);
+
+        ChattingMessageDocument chatMessage = ChattingMessageDocument.builder()
+                .chattingRoomSeq(messageDto.getChattingRoomSeq())
+                .senderSeq(sender.getMemberSeq())
+                .senderName(sender.getMemberName())
+                .senderProfileImage(profileImage)
+                .message(messageDto.getMessage())
+                .createdAt(LocalDateTime.now())
+                .build();
+        chattingMessageRepository.save(chatMessage);
+
+        ChattingRoom room = chattingRoomRepository.findById(messageDto.getChattingRoomSeq())
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+        room.updateLastMessage(messageDto.getMessage(), chatMessage.getCreatedAt());
+
+        // 상대방을 직접 조회, '안 읽음' 상태를 true로 변경
+        ChattingParticipant participant = chattingParticipantRepository
+                .findByChattingRoom_ChattingRoomSeqAndMember_MemberSeqNot(room.getChattingRoomSeq(), sender.getMemberSeq())
+                .orElseThrow(() -> new IllegalArgumentException("상대방을 찾을 수 없습니다."));
+        participant.markAsUnread();
+
+        return ChattingMessageResponse.builder()
+                .chattingRoomSeq(chatMessage.getChattingRoomSeq())
+                .senderSeq(chatMessage.getSenderSeq())
+                .senderName(chatMessage.getSenderName())
+                .senderProfileImage(chatMessage.getSenderProfileImage())
+                .message(chatMessage.getMessage())
+                .sentAt(chatMessage.getCreatedAt())
+                .build();
+    }
+
+    /* 채팅방 상세 정보 및 이전 대화 내역 조회 */
+    @Override
+    @Transactional(readOnly = true)
+    public ChattingRoomDetailResponse getChattingRoomDetails(Long chattingRoomSeq, Long currentMemberSeq) {
+
+        ChattingRoom room = chattingRoomRepository.findByIdWithParticipants(chattingRoomSeq)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+        boolean isParticipant = room.getParticipants().stream()
+                .anyMatch(p -> p.getMember().getMemberSeq().equals(currentMemberSeq));
+        if (!isParticipant) {
+            throw new SecurityException("채팅방에 접근할 권한이 없습니다.");
+        }
+
+        // 참여자 프로필 한 번에 조회
+        List<ChattingRoomDetailResponse.ParticipantInfo> participants = room.getParticipants().stream()
+                .map(p -> {
+                    Member member = p.getMember();
+                    String profileImg = getProfileImage(member);
+                    return ChattingRoomDetailResponse.ParticipantInfo.builder()
+                            .memberSeq(member.getMemberSeq())
+                            .memberName(member.getMemberName())
+                            .profileImage(profileImg)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        // Mongo DB에서 메시지 내역 조회 및 반환
+        List<ChattingMessageResponse> messages = chattingMessageRepository.findByChattingRoomSeqOrderByCreatedAtAsc(chattingRoomSeq)
+                .stream()
+                .map(msg -> ChattingMessageResponse.builder()
+                        .chattingRoomSeq(msg.getChattingRoomSeq())
+                        .senderSeq(msg.getSenderSeq())
+                        .senderName(msg.getSenderName())
+                        .senderProfileImage(msg.getSenderProfileImage())
+                        .message(msg.getMessage())
+                        .sentAt(msg.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ChattingRoomDetailResponse.builder()
+                .chattingRoomSeq(room.getChattingRoomSeq())
+                .mentosTitle(room.getPayment().getReservation().getMentos().getMentosTitle())
+                .participants(participants)
+                .messages(messages)
+                .build();
+    }
+
+    // 프로필 이미지 가져오기
+    private String getProfileImage(Member member) {
+        if (member.getMemberType() == MemberType.MENTO) {
+            return mentoProfileRepository.findByMember_MemberSeq(member.getMemberSeq())
+                    .map(MentoProfile::getMentoProfileImage)
+                    .orElse(null); // 멘토인데 프로필이 없는 경우... 일단 null
+        } else {
+            return MENTI_DEFAULT_IMAGE; // 멘티는 기본 이미지
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChattingRoomListByMentosResponse> getChatRoomsByMentosForMentor(Long mentorId) {
+        List<ChattingRoom> allChatRooms = chattingRoomRepository.findAllByMentorIdGroupedByMentos(mentorId);
+        Map<Mentos, List<ChattingRoom>> groupedByMentos = allChatRooms.stream()
+                .collect(Collectors.groupingBy(room -> room.getPayment().getReservation().getMentos()));
+
+        return groupedByMentos.entrySet().stream()
+                .map(entry -> new ChattingRoomListByMentosResponse(
+                        entry.getKey().getMentosSeq(),
+                        entry.getKey().getMentosTitle(),
+                        entry.getValue(),
+                        mentorId
+                ))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Long chattingRoomSeq, Long memberSeq) {
+        // 참여 정보 조회 (채팅방 ID, 사용자 ID)
+        ChattingParticipant participant = chattingParticipantRepository.findByChattingRoom_ChattingRoomSeqAndMember_MemberSeq(chattingRoomSeq, memberSeq)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방 참여 정보를 찾을 수 없습니다."));
+
+        // ChattingParticipant 엔티티의 읽음 처리 메서드 호출
+        // 트랜잭션에 의해 메서드 끝날 때 변경 내용 자동 DB 반영 (hasUnreadMessage = false)
+        participant.markAsRead();
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/PaymentService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/PaymentService.java
@@ -1,0 +1,9 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.domain.payment.Payment;
+
+public interface PaymentService {
+
+    /* 결제 완료 처리 후 채팅 방 생성 */
+    Payment processPaymentCompletion(Long paymentId);
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/PaymentServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/PaymentServiceImpl.java
@@ -1,0 +1,36 @@
+package com.shinhanDS5gi.memento.service;
+
+import com.shinhanDS5gi.memento.domain.chat.ChattingRoom;
+import com.shinhanDS5gi.memento.domain.payment.Payment;
+import com.shinhanDS5gi.memento.repository.PaymentRepository;
+import com.shinhanDS5gi.memento.repository.chat.ChattingRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final ChattingRoomRepository chattingRoomRepository;
+
+    @Override
+    @Transactional
+    public Payment processPaymentCompletion(Long paymentId) {
+        // 결제 완료 로직 필요
+
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new IllegalArgumentException("결제 정보를 찾을 수 없습니다."));
+
+        // 결제 상태 변경 로직 필요
+
+        // 결제 완료 후 (성공 시) 채팅방 신규 생성
+        ChattingRoom newChatRoom = ChattingRoom.create(payment);
+
+        // 생성된 채팅방과 채팅 참여자 정보 DB에 저장
+        chattingRoomRepository.save(newChatRoom);
+
+        return payment;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/memento?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: memento
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/memento-chat # 로컬 MongoDB 주소 및 DB 이름
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 요약 (Summary)
- 멘티가 특정 멘토스에 대해 예약-결제 완료 시 채팅 기능이 활성화되고 채팅방이 생성됨.
- 멘토 또한 나의 멘티 관리에서 예비 멘티 혹은 멘티와의 채팅 기능 활성화 및 채팅방 생성됨.
- 해당 API는 웹소켓을 이용해 두 유저 간의 채팅을 실시간으로 가능하게 하고, 대화 내용을 저장하는 기능 구현임.
- 채팅방 정보, 최근 메시지 등을 관리하는 채팅방(Chatting_room) 테이블, 채팅의 안 읽은 메시지 유무 여부를 관리하는 채팅 참여자(Chatting_participant)를 MySQL DB에서 관리하고, 송수신자 이름, 프로필 이미지, 채팅 내용을 저장하는 (chat_messages)  공간은 MongoDB에서 따로 관리함.

## 🔑 변경 사항 (Key Changes)

- Chatting 에 필요한 implementation build.gradle에 추가.
1) implementation 'org.springframework.boot:spring-boot-starter-data-mongodb' (Mongo DB)
2) implementation 'org.springframework.boot:spring-boot-starter-websocket' (Websocket)

- Chatting 관련 Controller, Service, ServiceImpl, Repo, domain 생성
- 채팅 메시지 요청 응답, 채팅방 정보 및 멘토스 별 채팅방 목록을 위한 DTO 생성
- 채팅방 생성 시점이 멘티의 특정 멘토스 '결제 완료' 시점이므로 이를 위해 임의의 결제 API 호출 메서드 임시 추가.

## 📝 리뷰 요구사항 (To Reviewers)

- 테스트를 위해 아래 html 파일 다운로드 필요
[test-chat.html](https://github.com/user-attachments/files/22132217/test-chat.html)
- 더미 데이터 DB에 적용 필요함.
- 채팅 대화 내용이 제대로 저장되는지 확인을 위해서는 MongoDB와 MongoDB Compass 설치 필요. (여기선 결과물만 첨부하겠음.)

```
-- 1. 카테고리, 멘토, 멘티 회원 생성
INSERT INTO category (category_seq, category_name, category_description, status, created_at, modified_at)
VALUES (1, 'IT/개발', '설명', 'ACTIVE', NOW(), NOW());

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at) VALUES
(1, 'mentor_user', 'password', '김멘토', '010-1111-1111', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW()),
(2, 'mentee_user', 'password', '박멘티', '010-2222-2222', 'MENTI', '1995-01-01', 'ACTIVE', NOW(), NOW());

-- 2. 멘토(1)가 프로필을 생성한 상태
INSERT INTO mento_profile (mento_profile_seq, mento_profile_content, mento_profile_image, status, member_seq, created_at, modified_at)
VALUES (1, '김멘토의 프로필입니다.', 'https://s3.example.com/mentor_profile.jpg', 'ACTIVE', 1, NOW(), NOW())
ON DUPLICATE KEY UPDATE mento_profile_content = '김멘토의 프로필입니다.';

-- 3. 멘토(1)가 멘토링 게시글 생성
INSERT INTO mentos (mentos_seq, mentos_title, status, member_seq, category_seq, mentos_content, price, mentos_image, mentos_postcode, mentos_roadaddress, mentos_bname, created_at, modified_at)
VALUES (1, '채팅 최종 테스트 멘토링', 'ACTIVE', 1, 1, '내용', 1000, 'img.jpg', '123', '주소', '동', NOW(), NOW());

-- 4. 멘티(2)가 멘토링(1)을 예약하고 결제 완료
INSERT INTO reservation (reservation_seq, status, mentos_at, mentos_seq, member_seq, created_at, modified_at)
VALUES (1, 'ACTIVE', '2025-10-10 10:00:00', 1, 2, NOW(), NOW());

INSERT INTO payment (payment_seq, price, payed_at, pay_type, status, member_seq, reservation_seq, created_at, modified_at)
VALUES (1, 1000, NOW(), 'PAID', 'ACTIVE', 2, 1, NOW(), NOW());
```

## 확인 방법 
1. 서버 실행 후 먼저 더미 데이터를 DB에 적용한다. (1번 김멘토 (멘토) <-> 2번 박멘티 (멘티) / 1번 멘토스 결제 완료 상태)
2. 결제는 완료되었지만 채팅방 생성까지 진행되지 않고 있으므로 postman을 열고 결제 API 호출을 해줘야 한다.
3. Post 방식으로 'http://localhost:9999/api/payments/1/complete' 입력 후 Send.
<img width="1474" height="362" alt="image" src="https://github.com/user-attachments/assets/a9f8fe40-6888-462f-a369-743499ee45c1" />

4. 200 Ok 상태라면 DB 내 chatting_room 테이블에 채팅방이 생성되었는지 확인한다.
5. 첨부한 'test-chat.html' 파일을 열어야 하는데, 서로 다른 브라우저에서 각각 열어서 두 개의 창을 띄운다.
6. 먼저 서버 '연결'을 클릭하고 '연결됨' 결과를 확인한다.
7. 채팅방 구독에서 1 입력 후 '구독하기' 클릭. (채팅방 번호를 의미함. 라디오의 주파수와 같다.)
8. 메시지 보내기 항목에서 보내는 사람을 한 곳에서는 1, 다른 곳에서는 2로 설정하고 메시지 내용을 각각 입력한다.
9. 아래 수신된 메시지에서 상대방과 메시지 송 수신이 알맞게 되는지 확인한다.
![채팅](https://github.com/user-attachments/assets/8a5bf895-1ed9-4fed-b718-461ff9d72d49)
10. MongoDB 와 Compass를 설치했다면 이름과(Memento)와 port번호 (27017) 를 입력하고 연결하면 아래와 같이 대화 내용이 저장되는 것을 확인할 수 있다.
![채팅 2](https://github.com/user-attachments/assets/b4e75f44-e033-4a82-9cf5-6387a7b02abe)

