### PR TITLE
refactor : 신고내역 조회, 신고내역 상세 조회 수정 요청사항 반영 및 관련 DTO 생성

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.shinhanDS5gi.memento.controller;
 
 import com.shinhanDS5gi.memento.common.response.BaseResponse;
 import com.shinhanDS5gi.memento.dto.admin.CreateReportRequest;
+import com.shinhanDS5gi.memento.dto.admin.SelectReportDetailResponse;
 import com.shinhanDS5gi.memento.dto.admin.SelectReportResponse;
 import com.shinhanDS5gi.memento.service.MemberService;
 import com.shinhanDS5gi.memento.dto.admin.GetMemberListResponse;
@@ -71,8 +72,8 @@ public class AdminController {
 
     /* 특정 신고 내역 상세 조회 */
     @GetMapping("/reports/{reportSeq}")
-    public BaseResponse<SelectReportResponse> getReportById(@PathVariable("reportSeq") Long reportSeq) {
-        SelectReportResponse report = reportService.findReportById(reportSeq);
+    public BaseResponse<SelectReportDetailResponse> getReportById(@PathVariable("reportSeq") Long reportSeq) {
+        SelectReportDetailResponse report = reportService.findReportById(reportSeq);
         return new BaseResponse<>(report);
     }
 

--- a/src/main/java/com/shinhanDS5gi/memento/dto/admin/SelectReportDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/admin/SelectReportDetailResponse.java
@@ -7,18 +7,20 @@ import lombok.Getter;
 
 @Getter
 @Builder
-/* 모든 신고 내역 조회 */
-public class SelectReportResponse {
+/* 특정 신고 상세 내역 조회 */
+public class SelectReportDetailResponse {
 
     private final Long reportSeq;
     private final ReportType reportType;
+    private final String reportImage;
     private final String reporterName; // 신고자 이름
-    private final String  reportedMentosTitle;  // 신고된 멘토스 이름
+    private final String reportedMentosTitle;  // 신고된 멘토스 이름
 
-    public static SelectReportResponse from(Report report) {
-        return SelectReportResponse.builder()
+    public static SelectReportDetailResponse from(Report report) {
+        return SelectReportDetailResponse.builder()
                 .reportSeq(report.getReportSeq())
                 .reportType(report.getReportType())
+                .reportImage(report.getReportImage())
                 .reporterName(report.getMember().getMemberName())
                 .reportedMentosTitle(report.getMentos().getMentosTitle())
                 .build();

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.dto.admin.CreateReportRequest;
+import com.shinhanDS5gi.memento.dto.admin.SelectReportDetailResponse;
 import com.shinhanDS5gi.memento.dto.admin.SelectReportResponse;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,5 +23,5 @@ public interface ReportService {
     List<SelectReportResponse> findAllReports();
 
     /* 특정 신고 상세 내역 조회 */
-    SelectReportResponse findReportById(Long reportSeq);
+    SelectReportDetailResponse findReportById(Long reportSeq);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -11,6 +11,7 @@ import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.report.Report;
 import com.shinhanDS5gi.memento.domain.report.ReportHandleStatus;
 import com.shinhanDS5gi.memento.dto.admin.CreateReportRequest;
+import com.shinhanDS5gi.memento.dto.admin.SelectReportDetailResponse;
 import com.shinhanDS5gi.memento.dto.admin.SelectReportResponse;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import com.shinhanDS5gi.memento.repository.ReportRepository;
@@ -94,7 +95,7 @@ public class ReportServiceImpl implements ReportService {
                 .orElseThrow(()-> new MemberException(CANNOT_FOUND_MEMBER));
         Mentos reportedMentos = mentosRepository.findByMentosSeqAndStatus(requestDto.getMentosSeq(), BaseStatus.ACTIVE)
                 .orElseThrow(() -> new MentosException(CANNOT_FOUND_REPORT));
-        
+
         // 중복신고 방지 메서드
         if (reportRepository.existsByMember_MemberSeqAndMentos_MentosSeqAndReportTypeAndStatus(
                 memberSeq, requestDto.getMentosSeq(), requestDto.getReportType(), BaseStatus.ACTIVE
@@ -117,29 +118,15 @@ public class ReportServiceImpl implements ReportService {
         List<Report> reports = reportRepository.findAllWithMemberAndMentos(ReportHandleStatus.PENDING);
 
         return reports.stream()
-                .map(report -> SelectReportResponse.builder()
-                        .reportSeq(report.getReportSeq())
-                        .reportType(report.getReportType())
-                        .reporterName(report.getMember().getMemberName())
-                        .reportedMentosSeq(report.getMentos().getMentosSeq())
-                        .reportImage(report.getReportImage())
-                        .createdAt(report.getCreatedAt())
-                        .build())
+                .map(SelectReportResponse::from)
                 .collect(Collectors.toList());
     }
 
     /* 특정 신고 내역 상세 조회 */
     @Override
-    public SelectReportResponse findReportById(Long reportSeq) {
+    public SelectReportDetailResponse findReportById(Long reportSeq) {
         return reportRepository.findByIdWithMemberAndMentos(reportSeq)
-                .map(report -> SelectReportResponse.builder()
-                        .reportSeq(report.getReportSeq())
-                        .reportType(report.getReportType())
-                        .reportImage(report.getReportImage())
-                        .reporterName(report.getMember().getMemberName())
-                        .reportedMentosSeq(report.getMentos().getMentosSeq())
-                        .createdAt(report.getCreatedAt())
-                        .build())
-                .orElse(null);
+                .map(SelectReportDetailResponse::from)
+                .orElseThrow(() -> new ReportException(CANNOT_FOUND_REPORT));
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- 기 개발된 신고내역 조회, 특정 신고내역 상세조회 API에 대해 프론트 UI 화면에 알맞게 DTO 변경 

## 🔑 변경 사항 (Key Changes)

- 기존 공유하던 SelectReportResponse -> SelectReportResponse 와 SelectReportDetailResponse로 분리
- 화면에 표출되는 데이터만 응답받을 수 있도록 내용 정제 (신고 첨부 이미지는 상세 내역에서만 표현되도록 변경)

## 📝 리뷰 요구사항 (To Reviewers)

- 기존 신고 API 요청 방식 그대로 요청 시 기존과 다르게 필요한 데이터 값만 응답받는지 확인 필요.
- 더미 데이터 생성 (테스트용)
```
-- 1. 카테고리, 멘토, 멘티 회원 생성
INSERT INTO category (category_seq, category_name, category_description, status, created_at, modified_at)
VALUES (1, 'IT/개발', 'IT 및 개발 관련 카테고리입니다.', 'ACTIVE', NOW(), NOW());

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at) VALUES
(1, 'mentor_user', 'password123', '김멘토', '010-1111-1111', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW()),
(2, 'mentee_user', 'password123', '박멘티', '010-2222-2222', 'MENTI', '1995-01-01', 'ACTIVE', NOW(), NOW());

-- 2. 멘토(1)가 생성한 멘토링 게시글 생성 (구버전 스키마 - 장소 정보 포함)... 아직 멘토스, 멘토 프로필 정보가 merge 되지 않았으므로 구 버젼 구조로 더미데이터 생성함.
INSERT INTO mentos (mentos_seq, mentos_title, mentos_content, price, mentos_image, mentos_postcode, mentos_roadaddress, mentos_bname, mentos_detail, status, member_seq, category_seq, created_at, modified_at)
VALUES (1, '채팅 최종 테스트 멘토링', '이 멘토링은 구버전 스키마를 따릅니다.', 50000, 'chat.jpg', '12345', '서울시 강남구', '역삼동', '상세주소', 'ACTIVE', 1, 1, NOW(), NOW());

```
## 확인 방법 
1. 먼저 신고 작성하기 API를 요청한다.
- Post 방식으로 'http://localhost:9999/admin/reports' 주소로 설정한다.
- Header 항목에 Key를 Idem-Key, Value는 {{$guid}} 삽입
- Body-> form-data 클릭 후 Key에 requestDto, imageFile 입력한다.
- Value에는 아래 json 요청 값을 입력한다.
{
  "reportType": "COMMERCIAL_AD",
  "mentosSeq": 1
}
- 두 번째 value에는 파일 선택 후 파일 첨부.
<img width="1478" height="611" alt="image" src="https://github.com/user-attachments/assets/d52da1a8-479c-4fab-9e4b-8eff5345c2fc" />

2.  요청 성공 메시지가 떴다면 이제 모든 신고 내역 조회 요청을 한다.
- Get 방식으로 'http://localhost:9999/admin/reports' 주소로 설정하고 Send 한 후, 아래와 같이 데이터가 조회되는지 확인.
<img width="1472" height="584" alt="image" src="https://github.com/user-attachments/assets/d6dc702e-8da4-42fa-9618-97a2681903b0" />

3. 특정 신고내역 상세 조회 요청을 한다.
- Get 방식으로 'http://localhost:9999/admin/reports/1' 주소로 설정 (1번 시퀀스의 신고 내역) 하고 Send한다.
<img width="1472" height="628" alt="image" src="https://github.com/user-attachments/assets/57d356a9-0293-4edd-bc1c-195af67ef930" />
- 신고내역 조회에서 확인했던 데이터 내역 + 신고 이미지 경로, 멘토스 이름 등이 잘 조회되는지 확인하면 테스트 종료.