### PR TITLE
refactor : Mentos, MentoProfile 도메인 변경 및 후속 작업

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -78,17 +78,22 @@ public class MentosController {
     }
 
     /* 멘토스 생성하기 */
-    @PostMapping("/{memberSeq}")
-    public BaseResponse<Void> createMentos(@PathVariable("memberSeq") Long memberSeq,
-                                           @ModelAttribute CreateMentosRequest createMentosRequest,
-                                           @RequestHeader(value = "Idempotency-Key") String idemKey){
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<Void> createMentos(
+            @RequestPart("requestDto") CreateMentosRequest createMentosRequest,
+            @RequestPart("imageFile") MultipartFile imageFile,
+            @RequestHeader(value = "Idem-Key") String idemKey) throws IOException {
+
         log.info("[MentosController.createMentos]");
+
         // 프론트에서 멱등키가 같이 오지 않으면 생성이 안되도록 막기
-        if(idemKey.isEmpty()) {
+        if(idemKey == null || idemKey.isEmpty()) {
             throw new MentosException(CANNOT_CREATE_MENTOS);
         }
 
-        mentosService.createMentos(memberSeq, createMentosRequest, idemKey);
-        return new BaseResponse<>(null);
+        Long currentMemberSeq = 1L; // 임시 사용자 ID
+        mentosService.createMentos(currentMemberSeq, createMentosRequest, imageFile, idemKey);
+
+        return new BaseResponse<>(SUCCESS, null);
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Builder //엔티티에 저장하기 위해 넣었음
 @Entity
@@ -32,10 +32,10 @@ public class MentoProfile extends BaseTime {
     private String mentoProfileImage;
 
     @Column(nullable = false)
-    private LocalDateTime startTime;
+    private LocalTime startTime;
 
     @Column(nullable = false)
-    private LocalDateTime endTime;
+    private LocalTime endTime;
 
     @Column(nullable = false)
     private String mentoPostcode;

--- a/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/MentoProfile.java
@@ -4,11 +4,16 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.base.BaseTime;
 import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.dto.mento.UpdateMentoProfileRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
+@Builder //엔티티에 저장하기 위해 넣었음
 @Entity
 @Getter
 @NoArgsConstructor
@@ -26,6 +31,27 @@ public class MentoProfile extends BaseTime {
     @Column(nullable = false)
     private String mentoProfileImage;
 
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(nullable = false)
+    private String mentoPostcode;
+
+    @Column(nullable = false)
+    private String mentoRoadAddress;
+
+    @Column
+    private String mentoDetail;
+
+    @Column(nullable = false)
+    private String mentoBname;
+
+    @Column(nullable = false)
+    private String availableDays;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private BaseStatus status;
@@ -35,12 +61,26 @@ public class MentoProfile extends BaseTime {
     @JoinColumn(name = "member_seq", unique = true)
     private Member member;
 
-    /* 멘토 프로필 수정하기 */
-    public void update(String content, String imageUrl) {
-        this.mentoProfileContent = content;
+    public MentoProfile(String mentoProfileContent, String mentoProfileImage, BaseStatus status, Member member) {
+        this.mentoProfileContent = mentoProfileContent;
+        this.mentoProfileImage = mentoProfileImage;
+        this.status = status;
+        this.member = member;
+    }
 
-        if (imageUrl != null) {
-            this.mentoProfileImage = imageUrl;
+    /* 멘토 프로필 수정하기 */
+    public void update(UpdateMentoProfileRequest dto, String newImageUrl) {
+        this.mentoProfileContent = dto.getMentoProfileContent();
+        this.startTime = dto.getStartTime();
+        this.endTime = dto.getEndTime();
+        this.availableDays = dto.getAvailableDays();
+        this.mentoPostcode = dto.getMentoPostcode();
+        this.mentoRoadAddress = dto.getMentoRoadAddress();
+        this.mentoBname = dto.getMentoBname();
+        this.mentoDetail = dto.getMentoDetail();
+
+        if (newImageUrl != null) {
+            this.mentoProfileImage = newImageUrl;
         }
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/domain/Mentos.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/Mentos.java
@@ -37,17 +37,6 @@ public class Mentos extends BaseTime {
     @Column(nullable = false)
     private String mentosImage;
 
-    @Column(nullable = false)
-    private String mentosPostcode;
-
-    @Column(nullable = false)
-    private String mentosRoadaddress;
-
-    @Column(nullable = false)
-    private String mentosBname;
-
-    private String mentosDetail;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private BaseStatus status;
@@ -77,10 +66,6 @@ public class Mentos extends BaseTime {
         this.mentosTitle = requestDto.getMentosTitle();
         this.mentosContent = requestDto.getMentosContent();
         this.price = requestDto.getPrice();
-        this.mentosPostcode = requestDto.getMentosPostcode();
-        this.mentosRoadaddress = requestDto.getMentosRoadaddress();
-        this.mentosBname = requestDto.getMentosBname();
-        this.mentosDetail = requestDto.getMentosDetail();
         if (newImageUrl != null) {
             this.mentosImage = newImageUrl;
         }
@@ -92,16 +77,12 @@ public class Mentos extends BaseTime {
     }
 
     //멘토스 생성하기
-    public Mentos(String mentosTitle, String mentosContent, int price, String mentosImage, String mentosPostcode,
-                  String mentosRoadaddress, String mentosBname, String mentosDetail, Category category, Member member, BaseStatus status) {
+    public Mentos(String mentosTitle, String mentosContent, int price, String mentosImage,
+                  Category category, Member member, BaseStatus status) {
         this.mentosTitle = mentosTitle;
         this.mentosContent = mentosContent;
         this.price = price;
         this.mentosImage = mentosImage;
-        this.mentosPostcode = mentosPostcode;
-        this.mentosRoadaddress = mentosRoadaddress;
-        this.mentosBname = mentosBname;
-        this.mentosDetail = mentosDetail;
         this.category = category;
         this.member = member;
         this.status = status;

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
@@ -1,11 +1,14 @@
 package com.shinhanDS5gi.memento.dto.mento;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.shinhanDS5gi.memento.domain.MentoProfile;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -15,11 +18,40 @@ public class CreateMentoProfileRequest {
     @NotBlank(message = "멘토 소개 내용은 필수입니다.")
     private String mentoProfileContent;
 
+    @NotNull(message = "시작 시간은 필수입니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime startTime;
+
+    @NotNull(message = "종료 시간은 필수입니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime endTime;
+
+    @NotBlank(message = "진행 가능 요일은 필수입니다.")
+    private String availableDays;
+
+    @NotBlank(message = "우편번호는 필수입니다.")
+    private String mentoPostcode;
+
+    @NotBlank(message = "도로명 주소는 필수입니다.")
+    private String mentoRoadAddress;
+
+    @NotBlank(message = "법정동 이름은 필수입니다.")
+    private String mentoBname;
+
+    private String mentoDetail;
+
     public MentoProfile toEntity(Member member, String imageUrl) {
         return new MentoProfile(
                 null,
                 this.mentoProfileContent,
                 imageUrl,
+                this.startTime,
+                this.endTime,
+                this.availableDays,
+                this.mentoPostcode,
+                this.mentoRoadAddress,
+                this.mentoBname,
+                this.mentoDetail,
                 BaseStatus.ACTIVE,
                 member
         );

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
@@ -47,11 +47,11 @@ public class CreateMentoProfileRequest {
                 imageUrl,
                 this.startTime,
                 this.endTime,
-                this.availableDays,
                 this.mentoPostcode,
                 this.mentoRoadAddress,
-                this.mentoBname,
                 this.mentoDetail,
+                this.mentoBname,
+                this.availableDays,
                 BaseStatus.ACTIVE,
                 member
         );

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor
@@ -19,12 +19,12 @@ public class CreateMentoProfileRequest {
     private String mentoProfileContent;
 
     @NotNull(message = "시작 시간은 필수입니다.")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime startTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime startTime;
 
     @NotNull(message = "종료 시간은 필수입니다.")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime endTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime endTime;
 
     @NotBlank(message = "진행 가능 요일은 필수입니다.")
     private String availableDays;

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/UpdateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/UpdateMentoProfileRequest.java
@@ -1,8 +1,12 @@
 package com.shinhanDS5gi.memento.dto.mento;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 /* 멘토 프로필 수정을 위한 요청 DTO */
 @Getter
@@ -12,6 +16,25 @@ public class UpdateMentoProfileRequest {
     @NotBlank(message = "멘토 소개 내용은 필수입니다.")
     private String mentoProfileContent;
 
-    @NotBlank(message = "프로필 이미지는 필수입니다.")
-    private String mentoProfileImage;
+    @NotNull(message = "시작 시간은 필수입니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime startTime;
+
+    @NotNull(message = "종료 시간은 필수입니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime endTime;
+
+    @NotBlank(message = "진행 가능 요일은 필수입니다.")
+    private String availableDays;
+
+    @NotBlank(message = "우편번호는 필수입니다.")
+    private String mentoPostcode;
+
+    @NotBlank(message = "도로명 주소는 필수입니다.")
+    private String mentoRoadAddress;
+
+    @NotBlank(message = "법정동 이름은 필수입니다.")
+    private String mentoBname;
+
+    private String mentoDetail;
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/UpdateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/UpdateMentoProfileRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 /* 멘토 프로필 수정을 위한 요청 DTO */
 @Getter
@@ -17,12 +17,12 @@ public class UpdateMentoProfileRequest {
     private String mentoProfileContent;
 
     @NotNull(message = "시작 시간은 필수입니다.")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime startTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime startTime;
 
     @NotNull(message = "종료 시간은 필수입니다.")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime endTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime endTime;
 
     @NotBlank(message = "진행 가능 요일은 필수입니다.")
     private String availableDays;

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/CreateMentosRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/CreateMentosRequest.java
@@ -2,7 +2,6 @@ package com.shinhanDS5gi.memento.dto.mentos;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
@@ -17,8 +16,4 @@ public class CreateMentosRequest {
     private MultipartFile mentosImage;
     private Long categorySeq;
     private int price;
-    private String mentosPostcode;
-    private String mentosRoadaddress;
-    private String mentosBname;
-    private String mentosDetail;
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosDetailResponse.java
@@ -1,10 +1,11 @@
 package com.shinhanDS5gi.memento.dto.mentos;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -15,12 +16,39 @@ public class GetMentosDetailResponse {
      * 멘토스 상세조회 dto
      */
 
+    // Mentos 정보
     private final String mentosImage;
     private final String mentosTitle;
-    private final String mentosLocation;
+    private final String mentosDescription;
+    private final int mentosPrice;
+
+    // MentoProfile 정보 (장소 및 시간)
+    private final String mentoPostcode;
+    private final String mentoRoadAddress;
+    private final String mentoBname;
+    private final String mentoDetailAddress;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private final LocalDateTime startTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private final LocalDateTime endTime;
+    private final String availableDays;
+
+    // Mento 정보
+    private final MentoDetail mento;
+
+    // Review 정보
     private final Integer reviewTotalCnt;
     private final Double reviewRatingAvg;
     private final List<Review> reviews;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MentoDetail {
+        private final String mentoName;
+        private final String mentoImg;
+        private final String mentoDescription;
+    }
 
     @Getter
     @Builder
@@ -31,18 +59,4 @@ public class GetMentosDetailResponse {
         private final String reviewDate;
         private final String reviewContent;
     }
-
-    private final MentoDetail mento;
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class MentoDetail{
-        private final String mentoName;
-        private final String mentoImg;
-        private final String mentoDescription;
-    }
-
-    private final String mentosDescription;
-    private final int mentosPrice;
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosDetailResponse.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -27,10 +27,10 @@ public class GetMentosDetailResponse {
     private final String mentoRoadAddress;
     private final String mentoBname;
     private final String mentoDetailAddress;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private final LocalDateTime startTime;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private final LocalDateTime endTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private final LocalTime startTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private final LocalTime endTime;
     private final String availableDays;
 
     // Mento 정보

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosListResponse.java
@@ -1,6 +1,5 @@
 package com.shinhanDS5gi.memento.dto.mentos;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/UpdateMentosRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/UpdateMentosRequest.java
@@ -21,21 +21,4 @@ public class UpdateMentosRequest {
     @PositiveOrZero(message = "가격은 0 이상이어야 합니다.")
     private Integer price;
 
-    @NotBlank(message = "우편번호는 필수입니다.")
-    private String mentosPostcode;
-
-    @NotBlank(message = "도로명 주소는 필수입니다.")
-    private String mentosRoadaddress;
-
-    @NotBlank(message = "법정 동네 이름은 필수입니다.")
-    private String mentosBname;
-
-    private String mentosDetail;
-
-    @NotBlank(message = "첫 번째 키워드는 필수입니다.")
-    private String keywordOne;
-    @NotBlank(message = "두 번째 키워드는 필수입니다.")
-    private String keywordTwo;
-    @NotBlank(message = "세 번째 키워드는 필수입니다.")
-    private String keywordThree;
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mypage/MyMentosByMentiResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mypage/MyMentosByMentiResponse.java
@@ -22,12 +22,17 @@ public class MyMentosByMentiResponse {
         Mentos mentos = reservation.getMentos();
         String status = reservation.getMentosAt().isBefore(LocalDateTime.now()) ? "진행 완료" : "진행 전";
 
+        String region = null;
+        if (mentos.getMember() != null && mentos.getMember().getMentoProfile() != null) {
+            region = mentos.getMember().getMentoProfile().getMentoBname();
+        }
+
         return MyMentosByMentiResponse.builder()
                 .mentosSeq(mentos.getMentosSeq())
                 .mentosTitle(mentos.getMentosTitle())
                 .mentosImage(mentos.getMentosImage())
                 .price(mentos.getPrice())
-                .region(mentos.getMentosBname())
+                .region(region)
                 .progressStatus(status)
                 .build();
     }

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReservationRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReservationRepository.java
@@ -14,13 +14,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     Optional<Reservation> findByMember_MemberSeqAndMentos_MentosSeqAndStatus(Long memberSeq, Long mentosSeq, BaseStatus status);
 
     /* 멘토가 작성한 모든 멘토스의 예약 목록 조회 */
-    @Query("SELECT r FROM Reservation r JOIN FETCH r.mentos m JOIN FETCH r.member menti WHERE m.member.memberSeq = :mentorId AND r.status = 'ACTIVE' ORDER BY m.mentosSeq, r.mentosAt")
+    @Query("SELECT r FROM Reservation r " +
+            "JOIN FETCH r.mentos m " +
+            "JOIN FETCH m.member mem " +
+            "JOIN FETCH mem.mentoProfile mp " +
+            "JOIN FETCH r.member menti " +
+            "WHERE m.member.memberSeq = :mentorId AND r.status = 'ACTIVE' " +
+            "ORDER BY m.mentosSeq, r.mentosAt")
     List<Reservation> findAllByMentorId(@Param("mentorId") Long mentorId);
 
     /* 특정 멘티의 멘토스 예약 목록을 커서 기반 페이징으로 조회 */
     @Query("SELECT r FROM Reservation r " +
             "JOIN FETCH r.mentos m " +
-            "JOIN FETCH m.member " +
+            "JOIN FETCH m.member mem " +
+            "JOIN FETCH mem.mentoProfile mp " +
             "WHERE r.member.memberSeq = :memberSeq AND r.status = :status " +
             "ORDER BY " +
             "  CASE WHEN r.mentosAt > CURRENT_TIMESTAMP THEN 1 ELSE 2 END ASC, " +

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepositoryImpl.java
@@ -15,7 +15,6 @@ import com.shinhanDS5gi.memento.domain.QReview;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.QMember;
 import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailProjection;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailResponse;
 import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -51,9 +50,11 @@ public class MentosRepositoryImpl implements MentosCustomRepository {
                         mentos.mentosImage.as("mentosImg"),
                         mentos.mentosTitle,
                         mentos.price.as("mentosPrice"),
-                        mentos.mentosBname.as("region"),
+                        mentoProfile.mentoBname.as("region"),
                         new CaseBuilder().when(existsApproved).then(true).otherwise(false).as("approved")))
                 .from(mentos)
+                .join(mentos.member, member)
+                .leftJoin(mentoProfile).on(mentoProfile.member.eq(member))
                 .where(builder)
                 .orderBy(mentos.mentosSeq.desc())
                 .limit(limit + 1)
@@ -75,7 +76,8 @@ public class MentosRepositoryImpl implements MentosCustomRepository {
                         mentos.mentosTitle,
                         Expressions.stringTemplate(
                                 "concat({0}, ' ', coalesce({1}, ''))",
-                                mentos.mentosRoadaddress, mentos.mentosDetail
+                                mentoProfile.mentoRoadAddress,
+                                mentoProfile.mentoDetail
                         ).as("mentosLocation"),
                         reviewTotalCnt,
                         reviewRatingAvg,
@@ -84,8 +86,11 @@ public class MentosRepositoryImpl implements MentosCustomRepository {
                         mentoProfile.mentoProfileContent.as("mentoDescription"),
                         mentos.mentosContent.as("mentosDescription"),
                         mentos.price.as("mentosPrice")
-                )).from(mentos).join(mentos.member, member).leftJoin(mentoProfile)
-                .on(mentoProfile.member.eq(member))
-                .where(builder).fetchOne();
+                ))
+                .from(mentos)
+                .join(mentos.member, member)
+                .leftJoin(mentoProfile).on(mentoProfile.member.eq(member)) // ✅ location/description 조회 가능
+                .where(builder)
+                .fetchOne();
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
@@ -75,7 +75,7 @@ public class MentoProfileServiceImpl implements MentoProfileService {
         MentoProfile mentoProfile = mentoProfileRepository.findByMember_MemberSeq(memberSeq)
                 .orElseThrow(() -> new MentoProfileException(CANNOT_FOUND_MENTO_PROFILE));
 
-        String newImageUrl = null;
+        String newImageUrl = mentoProfile.getMentoProfileImage();
 
         if (imageFile != null && !imageFile.isEmpty()) {
 
@@ -83,6 +83,6 @@ public class MentoProfileServiceImpl implements MentoProfileService {
             newImageUrl = s3Uploader.upload(imageFile);
         }
 
-        mentoProfile.update(requestDto.getMentoProfileContent(), newImageUrl);
+        mentoProfile.update(requestDto, newImageUrl);
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
@@ -28,6 +28,6 @@ public interface MentosService {
     GetMentosListResponse getMentosList(Long mentosCategorySeq, Integer limit, Long cursor);
 
     /* 멘토스 생성하기 */
-    void createMentos(Long memberSeq, CreateMentosRequest createMentosRequest, String idemKey);
+    void createMentos(Long memberSeq, CreateMentosRequest dto, MultipartFile file, String idemKey) throws IOException;
 
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -5,6 +5,7 @@ import com.shinhanDS5gi.memento.common.exception.MemberException;
 import com.shinhanDS5gi.memento.common.exception.MentosException;
 import com.shinhanDS5gi.memento.config.S3Uploader;
 import com.shinhanDS5gi.memento.domain.Category;
+import com.shinhanDS5gi.memento.domain.MentoProfile;
 import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
@@ -13,11 +14,11 @@ import com.shinhanDS5gi.memento.dto.mentos.MyMentosResponse;
 import com.shinhanDS5gi.memento.dto.mentos.MyMentosSliceResponse;
 import com.shinhanDS5gi.memento.dto.mentos.UpdateMentosRequest;
 import com.shinhanDS5gi.memento.dto.mentos.CreateMentosRequest;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailProjection;
 import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailResponse;
-import com.shinhanDS5gi.memento.repository.Review.ReviewRepository;
+import com.shinhanDS5gi.memento.repository.MentoProfileRepository;
 import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
 import com.shinhanDS5gi.memento.repository.CategoryRepository;
+import com.shinhanDS5gi.memento.repository.Review.ReviewRepository;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import lombok.RequiredArgsConstructor;
@@ -43,8 +44,9 @@ public class MentosServiceImpl implements MentosService {
 
     private final MemberRepository memberRepository;
     private final MentosRepository mentosRepository;
-    private final ReviewRepository reviewRepository;
     private final CategoryRepository categoryRepository;
+    private final MentoProfileRepository mentoProfileRepository;
+    private final ReviewRepository reviewRepository;
 
     private final S3Uploader s3Uploader;
     private final IdempotencyService idempotencyService;
@@ -54,6 +56,11 @@ public class MentosServiceImpl implements MentosService {
     public MyMentosSliceResponse<MyMentosResponse> getMyMentosSlice(Long currentMemberId, Long cursor, int limit) {
         // 첫 페이지 요청 시 cursor 초기값 설정
         Long currentCursor = (cursor == null) ? Long.MAX_VALUE : cursor;
+
+        // 멘토의 프로필의 장소 정보 조회
+        MentoProfile mentoProfile = mentoProfileRepository.findByMember_MemberSeq(currentMemberId)
+                .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTO_PROFILE));
+        String region = mentoProfile.getMentoBname();
 
         // Repository 호출
         Slice<Mentos> mentosSlice = mentosRepository.findMyMentosSlice(
@@ -75,7 +82,7 @@ public class MentosServiceImpl implements MentosService {
                         .mentosTitle(mentos.getMentosTitle())
                         .mentosImage(mentos.getMentosImage())
                         .price(mentos.getPrice())
-                        .region(mentos.getMentosBname())
+                        .region(region)
                         .build())
                 .collect(Collectors.toList());
 
@@ -134,19 +141,53 @@ public class MentosServiceImpl implements MentosService {
     @Override
     public GetMentosDetailResponse getMentosDetail(Long mentosSeq) {
         log.info("[MentosServiceImpl.getMentosDetail]");
-        Mentos mentos = mentosRepository.findByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE).orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTOS));
 
-        GetMentosDetailProjection projection = mentosRepository.findMentosDetailByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE);
-        List<GetMentosDetailResponse.Review> review = reviewRepository.findReviewByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE);
+        // Mentos 정보 조회
+        Mentos mentos = mentosRepository.findByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE)
+                .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTOS));
 
-        GetMentosDetailResponse resultResponse = GetMentosDetailResponse.builder().mentosImage(projection.getMentosImage())
-                .mentosTitle(projection.getMentosTitle()).mentosLocation(projection.getMentosLocation())
-                .reviewTotalCnt(projection.getReviewTotalCnt()).reviewRatingAvg(projection.getReviewRatingAvg())
-                .reviews(review).mento(GetMentosDetailResponse.MentoDetail.builder().mentoName(projection.getMentoName())
-                        .mentoImg(projection.getMentoImg()).mentoDescription(projection.getMentoDescription()).build())
-                .mentosDescription(projection.getMentosDescription()).mentosPrice(projection.getMentosPrice()).build();
+        // Mentos를 등록한 멘토의 MentoProfile 정보 조회
+        MentoProfile mentoProfile = mentoProfileRepository.findByMember_MemberSeq(mentos.getMember().getMemberSeq())
+                .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTO_PROFILE));
 
-        return resultResponse;
+        // 리뷰 정보 조회
+        List<GetMentosDetailResponse.Review> reviews = reviewRepository.findReviewByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE);
+
+        Integer reviewTotalCnt = reviews.size();
+
+        Double reviewRatingAvg = reviews.stream()
+                .mapToInt(GetMentosDetailResponse.Review::getReviewRating)
+                .average()
+                .orElse(0.0);
+        // 소수점 두 번째 자리에서 반올림
+        reviewRatingAvg = Math.round(reviewRatingAvg * 100) / 100.0;
+
+        // 최종 응답 DTO 조립
+        return GetMentosDetailResponse.builder()
+                // Mentos 정보
+                .mentosImage(mentos.getMentosImage())
+                .mentosTitle(mentos.getMentosTitle())
+                .mentosDescription(mentos.getMentosContent())
+                .mentosPrice(mentos.getPrice())
+                // MentoProfile 정보
+                .mentoPostcode(mentoProfile.getMentoPostcode())
+                .mentoRoadAddress(mentoProfile.getMentoRoadAddress())
+                .mentoBname(mentoProfile.getMentoBname())
+                .mentoDetailAddress(mentoProfile.getMentoDetail())
+                .startTime(mentoProfile.getStartTime())
+                .endTime(mentoProfile.getEndTime())
+                .availableDays(mentoProfile.getAvailableDays())
+                // Mento 정보
+                .mento(GetMentosDetailResponse.MentoDetail.builder()
+                        .mentoName(mentoProfile.getMember().getMemberName())
+                        .mentoImg(mentoProfile.getMentoProfileImage())
+                        .mentoDescription(mentoProfile.getMentoProfileContent())
+                        .build())
+                // Review 정보
+                .reviews(reviews)
+                .reviewTotalCnt(reviewTotalCnt)
+                .reviewRatingAvg(reviewRatingAvg)
+                .build();
     }
 
     /* 멘토스 전체조회(카테고리별) */
@@ -170,33 +211,39 @@ public class MentosServiceImpl implements MentosService {
     }
 
     /* 멘토스 생성하기 */
-    @Transactional
     @Override
-    public void createMentos(Long memberSeq, CreateMentosRequest createMentosRequest, String idemKey) {
+    @Transactional
+    public void createMentos(Long memberSeq, CreateMentosRequest createMentosRequest, MultipartFile imageFile, String idemKey) throws IOException {
         log.info("[MentosServiceImpl.createMentos]");
-        try {
-            Member member = memberRepository.findByMemberSeqAndStatusAndMemberType(memberSeq, BaseStatus.ACTIVE, MemberType.MENTO)
-                    .orElseThrow(() -> new MemberException(NOT_A_MENTO));
 
-            log.info("[MentosServiceImpl.createMentos]....categorySeq==>" + createMentosRequest.getCategorySeq());
-            Category category = categoryRepository.findByCategorySeqAndStatus(createMentosRequest.getCategorySeq(), BaseStatus.ACTIVE)
-                    .orElseThrow(() -> new CategoryException(CANNOT_FOUND_CATEGORY));
-
-            if (idempotencyService.isDuplicate(idemKey)) {
-                log.info("[MentosServiceImpl.createMentos...멘토스 생성 이미 완료...동일한 요청]");
-                throw new MentosException(ALREADY_SUCCESS_REQUEST);
-            } else {
-                // s3 에 업로드된 url 로 db 에 저장하기
-                String uploadedMentosImage = s3Uploader.upload(createMentosRequest.getMentosImage());
-                Mentos mentos = new Mentos(createMentosRequest.getMentosTitle(), createMentosRequest.getMentosContent(), createMentosRequest.getPrice(), uploadedMentosImage, createMentosRequest.getMentosPostcode(),
-                        createMentosRequest.getMentosRoadaddress(), createMentosRequest.getMentosBname(), createMentosRequest.getMentosDetail(), category, member, BaseStatus.ACTIVE);
-
-                Mentos createdMentos = mentosRepository.save(mentos);
-                log.info("[MentosServiceImpl.createMentos...멘토스 생성 완료]");
-                idempotencyService.saveKey(idemKey, String.valueOf(createdMentos.getMentosSeq()));
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        if (idempotencyService.isDuplicate(idemKey)) {
+            log.warn("[MentosServiceImpl.createMentos] 멱등성 키 중복: {}", idemKey);
+            throw new MentosException(ALREADY_SUCCESS_REQUEST);
         }
+
+        Member member = memberRepository.findByMemberSeqAndStatusAndMemberType(memberSeq, BaseStatus.ACTIVE, MemberType.MENTO)
+                .orElseThrow(() -> new MemberException(NOT_A_MENTO));
+
+        Category category = categoryRepository.findByCategorySeqAndStatus(createMentosRequest.getCategorySeq(), BaseStatus.ACTIVE)
+                .orElseThrow(() -> new CategoryException(CANNOT_FOUND_CATEGORY));
+
+        String uploadedMentosImage = s3Uploader.upload(imageFile);
+
+        // 수정된 생성자 호출
+        Mentos mentos = new Mentos(
+                createMentosRequest.getMentosTitle(),
+                createMentosRequest.getMentosContent(),
+                createMentosRequest.getPrice(),
+                uploadedMentosImage,
+                category,
+                member,
+                BaseStatus.ACTIVE
+        );
+
+        Mentos createdMentos = mentosRepository.save(mentos);
+        log.info("[MentosServiceImpl.createMentos...멘토스 생성 완료]");
+
+        idempotencyService.saveKey(idemKey, String.valueOf(createdMentos.getMentosSeq()));
     }
+
 }


### PR DESCRIPTION
## 요약 (Summary)
- 멘토가 멘토링의 시간, 장소 정보 (시작 시간, 종료 시간, 활동 요일, 주소)를 멘토 프로필 화면에서 입력 및 수정되게 변경함으로써 필요한 작업 수행.
- 기존 Mentos 엔티티의 장소 정보 컬럼 삭제 (mentoPostCode, mentoRoadAddress, mentoDetail, mentoBname).
- 기존 MentoProfile 엔티티에 시간 정보(startTime, endTime, availableDays), 장소 정보 컬럼( '' ) 추가 
- 기 개발된 멘토스, 멘토 프로필 관련 API 변경 작업

## 🔑 변경 사항 (Key Changes)

- 두 엔티티의 변경으로 엔티티를 참조하는 모든 메서드 코드 변경.
ex ) 멘토스 생성하기, 수정하기, 상세조회 등 / 멘토 프로필 생성하기, 멘토 프로필 수정하기 등

## 📝 리뷰 요구사항 (To Reviewers)

- 앞서 언급한 각 API에 요청 값을 알맞게 넣고(mentos- 장소 컬럼 빼고 / mentoProfile - 시간, 장소 컬럼 넣고)  요청 시 이상없이 잘 구동되는지 확인한다.

ex) 멘토 프로필 수정하기 JSON request 요청
```
{
  "mentoProfileContent": "시간 정보가 수정되었습니다.",
  "startTime": "10:30",   -- 추가
  "endTime": "20:00",   -- 추가
  "availableDays": "화,목",   -- 추가
  "mentoPostcode": "54321",   -- 추가  
  "mentoRoadAddress": "경기도 성남시 분당구",   -- 추가
  "mentoBname": "판교동",   -- 추가
  "mentoDetailAddress": "카카오오피스"   -- 추가
}
```

## 확인 방법 
- 저장된 Postman API request 이용해 확인한다.