### PR TITLE
feat : 모든 신고 내역 조회하기 무한 스크롤 기능 추가 API 구현 완료

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/AdminController.java
@@ -1,11 +1,8 @@
 package com.shinhanDS5gi.memento.controller;
 
 import com.shinhanDS5gi.memento.common.response.BaseResponse;
-import com.shinhanDS5gi.memento.dto.admin.CreateReportRequest;
-import com.shinhanDS5gi.memento.dto.admin.SelectReportDetailResponse;
-import com.shinhanDS5gi.memento.dto.admin.SelectReportResponse;
+import com.shinhanDS5gi.memento.dto.admin.*;
 import com.shinhanDS5gi.memento.service.MemberService;
-import com.shinhanDS5gi.memento.dto.admin.GetMemberListResponse;
 import com.shinhanDS5gi.memento.service.ReportService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.SUCCESS;
 
@@ -65,8 +61,11 @@ public class AdminController {
 
     /* 모든 신고 내역 조회 */
     @GetMapping("/reports")
-    public BaseResponse<List<SelectReportResponse>> getAllReports() {
-        List<SelectReportResponse> reportAll = reportService.findAllReports();
+    public BaseResponse<SelectReportSliceResponse<SelectReportResponse>> getAllReports(
+            @RequestParam(defaultValue = "5") int limit,
+            @RequestParam(required = false) Long cursor
+    ) {
+        SelectReportSliceResponse<SelectReportResponse> reportAll = reportService.findAllReports(cursor, limit);
         return new BaseResponse<>(reportAll);
     }
 

--- a/src/main/java/com/shinhanDS5gi/memento/dto/admin/SelectReportSliceResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/admin/SelectReportSliceResponse.java
@@ -1,0 +1,16 @@
+package com.shinhanDS5gi.memento.dto.admin;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/* 모든 신고 내역 조회하기에서 커서 기반 페이징 응답을 위한 DTO */
+@Getter
+@Builder
+public class SelectReportSliceResponse<T> {
+
+    private final List<T> content; // 신고 내역 목록
+    private final Long nextCursor;
+    private final boolean hasNext; // 다음 페이지 존재 여부
+}

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReportRepository.java
@@ -4,6 +4,7 @@ import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.report.Report;
 import com.shinhanDS5gi.memento.domain.report.ReportHandleStatus;
 import com.shinhanDS5gi.memento.domain.report.ReportType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,9 +15,15 @@ import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-    /* PENDING 상태인 모든 신고 내역을 조회 */
-    @Query("SELECT r FROM Report r JOIN FETCH r.member m JOIN FETCH r.mentos mt WHERE r.handleStatus = :handleStatus")
-    List<Report> findAllWithMemberAndMentos(@Param("handleStatus") ReportHandleStatus handleStatus);
+    /* PENDING 상태인 모든 신고 내역을 조회 (최신 순) */
+    @Query("SELECT r FROM Report r " +
+            "JOIN FETCH r.member m " +
+            "JOIN FETCH r.mentos mt " +
+            "WHERE r.reportSeq < :cursor AND r.handleStatus = :handleStatus " +
+            "ORDER BY r.reportSeq DESC")
+    List<Report> findReportsAfterCursor(@Param("cursor") Long cursor,
+                                        @Param("handleStatus") ReportHandleStatus handleStatus,
+                                        Pageable pageable);
 
     /* reportSeq를 기준으로 특정 신고 내역 조회 */
     @Query("SELECT r FROM Report r JOIN FETCH r.member m JOIN FETCH r.mentos mt WHERE r.reportSeq = :reportSeq")

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportService.java
@@ -3,10 +3,10 @@ package com.shinhanDS5gi.memento.service;
 import com.shinhanDS5gi.memento.dto.admin.CreateReportRequest;
 import com.shinhanDS5gi.memento.dto.admin.SelectReportDetailResponse;
 import com.shinhanDS5gi.memento.dto.admin.SelectReportResponse;
+import com.shinhanDS5gi.memento.dto.admin.SelectReportSliceResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 public interface ReportService {
 
@@ -20,7 +20,7 @@ public interface ReportService {
     void createReport(Long memberSeq, CreateReportRequest requestDto, MultipartFile imageFile, String IdemKey) throws IOException;
 
     /* 모든 신고 내역 조회 */
-    List<SelectReportResponse> findAllReports();
+    SelectReportSliceResponse<SelectReportResponse> findAllReports(Long cursor, int limit);
 
     /* 특정 신고 상세 내역 조회 */
     SelectReportDetailResponse findReportById(Long reportSeq);

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReportServiceImpl.java
@@ -13,11 +13,13 @@ import com.shinhanDS5gi.memento.domain.report.ReportHandleStatus;
 import com.shinhanDS5gi.memento.dto.admin.CreateReportRequest;
 import com.shinhanDS5gi.memento.dto.admin.SelectReportDetailResponse;
 import com.shinhanDS5gi.memento.dto.admin.SelectReportResponse;
+import com.shinhanDS5gi.memento.dto.admin.SelectReportSliceResponse;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import com.shinhanDS5gi.memento.repository.ReportRepository;
 import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -114,12 +116,35 @@ public class ReportServiceImpl implements ReportService {
 
     /* 모든 신고 내역 조회 */
     @Override
-    public List<SelectReportResponse> findAllReports() {
-        List<Report> reports = reportRepository.findAllWithMemberAndMentos(ReportHandleStatus.PENDING);
+    public SelectReportSliceResponse<SelectReportResponse> findAllReports(Long cursor, int limit) {
+        // 첫 페이지 요청 시 cursor 초기화
+        Long currentCursor = (cursor == null) ? Long.MAX_VALUE : cursor;
 
-        return reports.stream()
+        // 다음 페이지 존재 여부 확인을 위해 limit + 1개 조회
+        PageRequest pageable = PageRequest.of(0, limit + 1);
+        List<Report> reports = reportRepository.findReportsAfterCursor(currentCursor, ReportHandleStatus.PENDING, pageable);
+
+        // 다음 페이지 존재하는가?
+        boolean hasNext = reports.size() > limit;
+
+        // hasNext가 true이면 마지막 데이터(limit+1) 제거
+        if (hasNext) {
+            reports.remove(limit);
+        }
+
+        // DTO 변환
+        List<SelectReportResponse> content = reports.stream()
                 .map(SelectReportResponse::from)
                 .collect(Collectors.toList());
+
+        // 마지막 조회 데이터의 reportSeq를 다음 커서로 설정
+        Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getReportSeq();
+
+        return SelectReportSliceResponse.<SelectReportResponse>builder()
+                .content(content)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
     }
 
     /* 특정 신고 내역 상세 조회 */


### PR DESCRIPTION
## 요약 (Summary)
- 기 개발 항목인 '모든 신고내역 조회하기'에서 조회 성능 향상을 위해 무한스크롤 기능 추가
- 관리자 계정을 들어가 요청 신고 항목 클릭 시 신고 상태가 'Pending'인 내역이 모두 조회되는데, 이때 5개 항목씩 무한 스크롤 형태로 페이징되어 뿌려질 수 있도록 조치함.
- 신고 승인 혹은 거절 시 ReportHandleStatus가 'approved' 혹은 'rejected'로 변경되면 더이상 조회되지 않음.

## 🔑 변경 사항 (Key Changes)

- Report 관련 파일 항목인 AdminController, reportService, reportServiceImpl, ReportRepository에 코드 수정
- 응답 DTO인 SelectReportResponse 내용을 수정하고, 페이징 처리를 위한 DTO인 SelectReportSliceResponse DTO 신규 생성

## 📝 리뷰 요구사항 (To Reviewers)

- Postman으로 테스트하기 위해 서버 실행 후 아래 더미데이터 DB에 추가 필요함. (신고 내역 15개 추가)
```
-- 1. (필수) 카테고리, 멘토, 멘티들 생성
INSERT INTO category (category_seq, category_name, category_description, status, created_at, modified_at)
VALUES (1, 'IT/개발', 'IT 및 개발 관련 카테고리입니다.', 'ACTIVE', NOW(), NOW());

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at) VALUES
(1, 'mentor_user', 'password123', '김멘토', '010-1111-1111', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW()),
(2, 'mentee_reporter1', 'password123', '박신고', '010-2222-2222', 'MENTI', '1995-01-01', 'ACTIVE', NOW(), NOW()),
(3, 'mentee_reporter2', 'password123', '이신고', '010-3333-3333', 'MENTI', '1998-01-01', 'ACTIVE', NOW(), NOW());

-- 2. (필수) 김멘토(1)가 작성한, 신고 대상 멘토링 게시글 생성
INSERT INTO mentos (mentos_seq, mentos_title, mentos_content, price, mentos_image, status, member_seq, category_seq, created_at, modified_at)
VALUES (1, '신고 테스트용 멘토링', '내용', 10000, 'image.jpg', 'ACTIVE', 1, 1, NOW(), NOW());

-- 3. (필수) 처리 대기(PENDING) 상태인 신고 내역 15건 추가
INSERT INTO report (report_seq, report_type, report_image, status, handle_status, member_seq, mentos_seq, created_at, modified_at) VALUES
(10, 'COMMERCIAL_AD', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW()),
(11, 'ABUSIVE_LANGUAGE', 's3_url', 'ACTIVE', 'PENDING', 3, 1, NOW(), NOW()),
(12, 'ABUSING', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW()),
(13, 'COMMERCIAL_AD', 's3_url', 'ACTIVE', 'PENDING', 3, 1, NOW(), NOW()),
(14, 'ABUSIVE_LANGUAGE', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW()),
(15, 'ABUSING', 's3_url', 'ACTIVE', 'PENDING', 3, 1, NOW(), NOW()),
(16, 'COMMERCIAL_AD', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW()),
(17, 'ABUSIVE_LANGUAGE', 's3_url', 'ACTIVE', 'PENDING', 3, 1, NOW(), NOW()),
(18, 'ABUSING', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW()),
(19, 'COMMERCIAL_AD', 's3_url', 'ACTIVE', 'PENDING', 3, 1, NOW(), NOW()),
(20, 'ABUSIVE_LANGUAGE', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW()),
(21, 'ABUSING', 's3_url', 'ACTIVE', 'PENDING', 3, 1, NOW(), NOW()),
(22, 'COMMERCIAL_AD', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW()),
(23, 'ABUSIVE_LANGUAGE', 's3_url', 'ACTIVE', 'PENDING', 3, 1, NOW(), NOW()),
(24, 'ABUSING', 's3_url', 'ACTIVE', 'PENDING', 2, 1, NOW(), NOW());

-- 4. (필수) 필터링 테스트를 위한 다른 상태의 신고 내역 2건 추가
INSERT INTO report (report_seq, report_type, report_image, status, handle_status, member_seq, mentos_seq, created_at, modified_at) VALUES
(25, 'ABUSING', 's3_url', 'ACTIVE', 'APPROVED', 2, 1, NOW(), NOW()), -- 승인 (조회되면 안 됨)
(26, 'COMMERCIAL_AD', 's3_url', 'ACTIVE', 'REJECTED', 3, 1, NOW(), NOW()); -- 거부 (조회되면 안 됨)

select * from report;
```

## 확인 방법 
1. 포스트맨을 열고 Get 요청 방식으로 아래 주소로 경로 설정한다. (첫 페이지)
```
http://localhost:9999/admin/reports?limit=5
```
<img width="1471" height="918" alt="image" src="https://github.com/user-attachments/assets/68dbe4d9-df89-4ad0-a860-9f575c5db797" />

2. 값이 이미지와 같이 알맞게 조회 (5개 당 1페이지씩 분할하여 조회) 되면 아래 주소로 경로 설정한다. (cursor 값 추가 요청)
```
http://localhost:9999/admin/reports?limit=5&cursor=20
```
<img width="1474" height="927" alt="image" src="https://github.com/user-attachments/assets/c1a2acb2-4aff-4151-8332-defcba3981a3" />

3. 마지막으로 마지막 페이지인 아래 주소로 경로 설정해 Send한다. 해당 페이지는 마지막 페이지로, hasNext가 false인지 확인한다.
```
http://localhost:9999/admin/reports?limit=5&cursor=15
```
<img width="1471" height="910" alt="image" src="https://github.com/user-attachments/assets/5a19a989-fcf8-4862-bb06-df85190786a2" />
