### PR TITLE
fix: GetMentosDetailResponse dto 수정 및 서비스코드 수정

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetMentosDetailResponse.java
@@ -15,40 +15,12 @@ public class GetMentosDetailResponse {
     /**
      * 멘토스 상세조회 dto
      */
-
-    // Mentos 정보
     private final String mentosImage;
     private final String mentosTitle;
-    private final String mentosDescription;
-    private final int mentosPrice;
-
-    // MentoProfile 정보 (장소 및 시간)
-    private final String mentoPostcode;
-    private final String mentoRoadAddress;
-    private final String mentoBname;
-    private final String mentoDetailAddress;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-    private final LocalTime startTime;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-    private final LocalTime endTime;
-    private final String availableDays;
-
-    // Mento 정보
-    private final MentoDetail mento;
-
-    // Review 정보
+    private final String mentosLocation;
     private final Integer reviewTotalCnt;
     private final Double reviewRatingAvg;
     private final List<Review> reviews;
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class MentoDetail {
-        private final String mentoName;
-        private final String mentoImg;
-        private final String mentoDescription;
-    }
 
     @Getter
     @Builder
@@ -59,4 +31,18 @@ public class GetMentosDetailResponse {
         private final String reviewDate;
         private final String reviewContent;
     }
+
+    private final MentoDetail mento;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MentoDetail{
+        private final String mentoName;
+        private final String mentoImg;
+        private final String mentoDescription;
+    }
+
+    private final String mentosDescription;
+    private final int mentosPrice;
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -10,16 +10,11 @@ import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.member.MemberType;
+import com.shinhanDS5gi.memento.dto.mentos.*;
 import com.shinhanDS5gi.memento.repository.mento.MentoProfileRepository;
 import com.shinhanDS5gi.memento.repository.CategoryRepository;
 import com.shinhanDS5gi.memento.repository.review.ReviewRepository;
-import com.shinhanDS5gi.memento.dto.mentos.MyMentosResponse;
-import com.shinhanDS5gi.memento.dto.mentos.MyMentosSliceResponse;
-import com.shinhanDS5gi.memento.dto.mentos.UpdateMentosRequest;
-import com.shinhanDS5gi.memento.dto.mentos.CreateMentosRequest;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailResponse;
 
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +31,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.*;
+import static com.shinhanDS5gi.memento.domain.QReview.review;
 
 @Slf4j
 @Service
@@ -147,48 +143,15 @@ public class MentosServiceImpl implements MentosService {
         Mentos mentos = mentosRepository.findByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE)
                 .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTOS));
 
-        // Mentos를 등록한 멘토의 MentoProfile 정보 조회
-        MentoProfile mentoProfile = mentoProfileRepository.findByMember_MemberSeq(mentos.getMember().getMemberSeq())
-                .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTO_PROFILE));
+        GetMentosDetailProjection projection = mentosRepository.findMentosDetailByMentosSeqAndStatus(mentos.getMentosSeq(), BaseStatus.ACTIVE);
 
-        // 리뷰 정보 조회
-        List<GetMentosDetailResponse.Review> reviews = reviewRepository.findReviewByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE);
-
-        Integer reviewTotalCnt = reviews.size();
-
-        Double reviewRatingAvg = reviews.stream()
-                .mapToInt(GetMentosDetailResponse.Review::getReviewRating)
-                .average()
-                .orElse(0.0);
-        // 소수점 두 번째 자리에서 반올림
-        reviewRatingAvg = Math.round(reviewRatingAvg * 100) / 100.0;
-
-        // 최종 응답 DTO 조립
-        return GetMentosDetailResponse.builder()
-                // Mentos 정보
-                .mentosImage(mentos.getMentosImage())
-                .mentosTitle(mentos.getMentosTitle())
-                .mentosDescription(mentos.getMentosContent())
-                .mentosPrice(mentos.getPrice())
-                // MentoProfile 정보
-                .mentoPostcode(mentoProfile.getMentoPostcode())
-                .mentoRoadAddress(mentoProfile.getMentoRoadAddress())
-                .mentoBname(mentoProfile.getMentoBname())
-                .mentoDetailAddress(mentoProfile.getMentoDetail())
-                .startTime(mentoProfile.getStartTime())
-                .endTime(mentoProfile.getEndTime())
-                .availableDays(mentoProfile.getAvailableDays())
-                // Mento 정보
-                .mento(GetMentosDetailResponse.MentoDetail.builder()
-                        .mentoName(mentoProfile.getMember().getMemberName())
-                        .mentoImg(mentoProfile.getMentoProfileImage())
-                        .mentoDescription(mentoProfile.getMentoProfileContent())
-                        .build())
-                // Review 정보
-                .reviews(reviews)
-                .reviewTotalCnt(reviewTotalCnt)
-                .reviewRatingAvg(reviewRatingAvg)
-                .build();
+        List<GetMentosDetailResponse.Review> review = reviewRepository.findReviewByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE);
+        return GetMentosDetailResponse.builder().mentosImage(projection.getMentosImage())
+                .mentosTitle(projection.getMentosTitle()).mentosLocation(projection.getMentosLocation())
+                .reviewTotalCnt(projection.getReviewTotalCnt()).reviewRatingAvg(projection.getReviewRatingAvg())
+                .reviews(review).mento(GetMentosDetailResponse.MentoDetail.builder().mentoName(projection.getMentoName())
+                        .mentoImg(projection.getMentoImg()).mentoDescription(projection.getMentoDescription()).build())
+                .mentosDescription(projection.getMentosDescription()).mentosPrice(projection.getMentosPrice()).build();
     }
 
     /* 멘토스 전체조회(카테고리별) */


### PR DESCRIPTION
## 요약 (Summary)
- [x] 멘토스 상세보기 에서 기존 dto 코드 살리며, 필요한 응답만 전송하도록 서비스코드 함께 수정하는 작업 진행하였습니다.

## 🔑 변경 사항 (Key Changes)

- GetMentosDetailResponse dto 와 MentosServiceImpl 코드 수정하였습니다.

## 확인 방법 
[기존의 멘토스 상세조회](https://github.com/ShinhanDSproject1/memento_Backend/pull/58)
[DB 쿼리문 모아둔 링크](https://paint-doll-0ba.notion.site/DB-Query-256fa60ecd058063adbfc58d3afae888)

위의 링크에서 쿼리문을 모두 실행시켜주시고, 기존의 멘토스 상세조회와 동일하게(url 에 /api 추가해야함, 로그인해서 토큰 넣는 것도 추가해야함) 요청 보내주시면 응답이 잘 오는 것을 확인하실 수 있습니다.
<img width="1624" height="1056" alt="스크린샷 2025-09-16 10 30 03" src="https://github.com/user-attachments/assets/49a5a525-ab65-4f20-b337-f8b86716f54c" />
