### PR TITLE
feat: 멘토스 수정하기 관련 요청사항 반영

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -3,12 +3,7 @@ package com.shinhanDS5gi.memento.controller;
 import com.shinhanDS5gi.memento.common.exception.MentosException;
 import com.shinhanDS5gi.memento.common.response.BaseResponse;
 import com.shinhanDS5gi.memento.domain.member.Member;
-import com.shinhanDS5gi.memento.dto.mentos.MyMentosResponse;
-import com.shinhanDS5gi.memento.dto.mentos.MyMentosSliceResponse;
-import com.shinhanDS5gi.memento.dto.mentos.UpdateMentosRequest;
-import com.shinhanDS5gi.memento.dto.mentos.CreateMentosRequest;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailResponse;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
+import com.shinhanDS5gi.memento.dto.mentos.*;
 import com.shinhanDS5gi.memento.security.CurrentUser;
 import com.shinhanDS5gi.memento.service.MentosService;
 import lombok.RequiredArgsConstructor;
@@ -101,5 +96,13 @@ public class MentosController {
         mentosService.createMentos(currentMemberSeq, createMentosRequest, idemKey);
 
         return new BaseResponse<>(null);
+    }
+
+    /* 멘토스 수정할 때 수정 전 정보를 불러와서 보여주는 api */
+    @GetMapping("/{mentosSeq}")
+    public BaseResponse<ShowMentosDetailForUpdateResponse> showMentosDetailForUpdate(@CurrentUser Member member,
+                                                                                     @PathVariable("mentosSeq") Long mentosSeq){
+        log.info("[MentosController.showMentosDetailForUpdate]");
+        return new BaseResponse<>(mentosService.showMentosDetailForUpdate(member, mentosSeq));
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -43,7 +43,7 @@ public class MentosController {
     }
 
     /* 멘토스 게시글 수정 */
-    @PutMapping(value = "/{mentosSeq}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping("/{mentosSeq}")
     public BaseResponse<Void> updateMentos(
             @CurrentUser Member member,
             @PathVariable("mentosSeq") Long mentosSeq,

--- a/src/main/java/com/shinhanDS5gi/memento/domain/Mentos.java
+++ b/src/main/java/com/shinhanDS5gi/memento/domain/Mentos.java
@@ -63,13 +63,14 @@ public class Mentos extends BaseTime {
     private List<Review> reviewList = new ArrayList<>();
 
     /* 멘토스 정보 수정*/
-    public void update(UpdateMentosRequest requestDto, String newImageUrl) {
+    public void update(UpdateMentosRequest requestDto, String newImageUrl, Category category) {
         this.mentosTitle = requestDto.getMentosTitle();
         this.mentosContent = requestDto.getMentosContent();
         this.price = requestDto.getPrice();
         if (newImageUrl != null) {
             this.mentosImage = newImageUrl;
         }
+        this.category = category;
     }
 
     /* 멘토스 상태 비활성화 */

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/ShowMentosDetailForUpdateResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/ShowMentosDetailForUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.shinhanDS5gi.memento.dto.mentos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ShowMentosDetailForUpdateResponse {
+    /**
+     * 멘토스 수정할 때 수정하기 이전 값을 불러오기 위한 api dto
+     */
+    private Long mentosSeq;
+    private String mentosTitle;
+    private Long categorySeq;
+    private String mentosContent;
+    private String mentosImage;
+    private int price;
+
+}

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/UpdateMentosRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/UpdateMentosRequest.java
@@ -17,6 +17,8 @@ public class UpdateMentosRequest {
     @NotBlank(message = "내용은 필수입니다.")
     private String mentosContent;
 
+    private Long categorySeq;
+
     @NotNull(message = "가격은 필수입니다.")
     @PositiveOrZero(message = "가격은 0 이상이어야 합니다.")
     private Integer price;

--- a/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/mentos/MentosRepository.java
@@ -46,4 +46,6 @@ public interface MentosRepository extends JpaRepository<Mentos, Long>, MentosCus
         and me.status = :status
     """)
     Optional<MentoTimeWindowProjection> findTimeWindowByMentosSeqAndStatus(@Param("mentosSeq") Long mentosSeq, @Param("status") BaseStatus status);
+
+    Optional<Mentos> findByMentosSeqAndMember_MemberSeqAndStatus(Long mentosSeq, Long memberSeq, BaseStatus baseStatus);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
@@ -1,11 +1,7 @@
 package com.shinhanDS5gi.memento.service;
 
-import com.shinhanDS5gi.memento.dto.mentos.MyMentosResponse;
-import com.shinhanDS5gi.memento.dto.mentos.MyMentosSliceResponse;
-import com.shinhanDS5gi.memento.dto.mentos.UpdateMentosRequest;
-import com.shinhanDS5gi.memento.dto.mentos.CreateMentosRequest;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailResponse;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosListResponse;
+import com.shinhanDS5gi.memento.domain.member.Member;
+import com.shinhanDS5gi.memento.dto.mentos.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -30,4 +26,5 @@ public interface MentosService {
     /* 멘토스 생성하기 */
     void createMentos(Long memberSeq, CreateMentosRequest createMentosRequest, String idemKey);
 
+    ShowMentosDetailForUpdateResponse showMentosDetailForUpdate(Member member, Long mentosSeq);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -115,8 +115,10 @@ public class MentosServiceImpl implements MentosService {
             s3Uploader.delete(mentos.getMentosImage());
             newImageUrl = s3Uploader.upload(imageFile);
         }
+        Category category = categoryRepository.findByCategorySeqAndStatus(requestDto.getCategorySeq(), BaseStatus.ACTIVE)
+                .orElseThrow(()->new CategoryException(CANNOT_FOUND_CATEGORY));
 
-        mentos.update(requestDto, newImageUrl);
+        mentos.update(requestDto, newImageUrl, category);
     }
 
     /* 멘토스 삭제하기 */

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -207,4 +207,21 @@ public class MentosServiceImpl implements MentosService {
         }
     }
 
+    @Override
+    public ShowMentosDetailForUpdateResponse showMentosDetailForUpdate(Member member, Long mentosSeq) {
+        log.info("[MentosServiceImpl.showMentosDetailForUpdate]");
+        Mentos mentos = mentosRepository.findByMentosSeqAndMember_MemberSeqAndStatus(mentosSeq,member.getMemberSeq(),BaseStatus.ACTIVE)
+                .orElseThrow(()-> new MentosException(CANNOT_FOUND_MENTOS));
+
+        ShowMentosDetailForUpdateResponse response = ShowMentosDetailForUpdateResponse.builder()
+                .mentosContent(mentos.getMentosContent())
+                .categorySeq(mentos.getCategory().getCategorySeq())
+                .mentosImage(mentos.getMentosImage())
+                .mentosSeq(mentosSeq)
+                .mentosTitle(mentos.getMentosTitle())
+                .price(mentos.getPrice()).build();
+
+        return response;
+    }
+
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 멘토스 수정하기 눌렀을 때 해당 멘토스 정보 불러오는 get 요청 api 작업
- [x] 멘토스 수정할 때 카테고리 수정 안되는 부분 수정작업 수행합니다.

## 🔑 변경 사항 (Key Changes)

- 멘토스 수정하기에서 categorySeq 추가로 전달하기 위해 dto 수정하였습니다.
- 멘토스 수정하기를 들어가자마자, 기존 데이터를 보여주기 위한 get 메서드 api 추가로 구현하였습니다. 

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 명세서 대로 구현되었는지 [api 명세서 바로가기](https://paint-doll-0ba.notion.site/271fa60ecd0580498b7ae4c1f9dc8eb2?source=copy_link)

## 확인 방법 
데이터베이스에 더미 데이터를 넣어두고 아래의 주소로 
postman 에서 헤더에 토큰을 추가한 상태로 Get 요청 보내주세요 
```
http://localhost:9999/api/mentos/1
```

<img width="1624" height="1056" alt="스크린샷 2025-09-17 17 09 36" src="https://github.com/user-attachments/assets/994fa459-d585-4252-a173-42a6c1f17540" />

다음과 같이 정상적으로 반영된 것 확인할 수 있습니다.