### PR TITLE
feat : 멘토 프로필 조회 API 추가 (누락된 기능)

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentoController.java
@@ -91,6 +91,14 @@ public class MentoController {
         return new BaseResponse<>(SUCCESS, null);
     }
 
+    /* 멘토 프로필 조회 */
+    @GetMapping("/mento-profiles")
+    public BaseResponse<MentoProfileResponse> getMentoProfile(@CurrentUser Member member) {
+        Long currentMemberSeq = member.getMemberSeq();
+        MentoProfileResponse profile = mentoProfileService.getMentoProfile(currentMemberSeq);
+        return new BaseResponse<>(SUCCESS, profile);
+    }
+
     /* 멘티 조회 (멘토스별 조회) */
     @GetMapping("/menti-list")
     public BaseResponse<List<MyMentiResponse>> getMyMentiList(@CurrentUser Member member) {

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/CreateMentoProfileRequest.java
@@ -52,7 +52,7 @@ public class CreateMentoProfileRequest {
                 this.mentoPostcode,
                 this.mentoRoadAddress,
                 this.mentoBname,
-                this.availableDays,
+                this.mentoDetail,
                 latitude,
                 longitude,
                 BaseStatus.ACTIVE,

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mento/MentoProfileResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mento/MentoProfileResponse.java
@@ -1,0 +1,39 @@
+package com.shinhanDS5gi.memento.dto.mento;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.shinhanDS5gi.memento.domain.MentoProfile;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class MentoProfileResponse {
+
+    private String mentoProfileImage;
+    private String mentoProfileContent;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime startTime;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+    private LocalTime endTime;
+
+    private String availableDays;
+    private String mentoPostcode;
+    private String mentoRoadAddress;
+    private String mentoBname;
+    private String mentoDetail;
+
+    public MentoProfileResponse(MentoProfile mentoProfile) {
+        this.mentoProfileImage = mentoProfile.getMentoProfileImage();
+        this.mentoProfileContent = mentoProfile.getMentoProfileContent();
+        this.startTime = mentoProfile.getStartTime();
+        this.endTime = mentoProfile.getEndTime();
+        this.availableDays = mentoProfile.getAvailableDays();
+        this.mentoPostcode = mentoProfile.getMentoPostcode();
+        this.mentoRoadAddress = mentoProfile.getMentoRoadAddress();
+        this.mentoBname = mentoProfile.getMentoBname();
+        this.mentoDetail = mentoProfile.getMentoDetail();
+    }
+}

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileService.java
@@ -1,6 +1,7 @@
 package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.dto.mento.CreateMentoProfileRequest;
+import com.shinhanDS5gi.memento.dto.mento.MentoProfileResponse;
 import com.shinhanDS5gi.memento.dto.mento.UpdateMentoProfileRequest;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,4 +14,7 @@ public interface MentoProfileService {
 
     /* 멘토 프로필 수정 */
     void updateMentoProfile(Long memberSeq, UpdateMentoProfileRequest requestDto, MultipartFile imageFile) throws IOException;
+
+    /* 멘토 프로필 조회 */
+    MentoProfileResponse getMentoProfile(Long memberSeq);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentoProfileServiceImpl.java
@@ -8,6 +8,7 @@ import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.member.MemberType;
 import com.shinhanDS5gi.memento.dto.mento.CreateMentoProfileRequest;
+import com.shinhanDS5gi.memento.dto.mento.MentoProfileResponse;
 import com.shinhanDS5gi.memento.dto.mento.UpdateMentoProfileRequest;
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import com.shinhanDS5gi.memento.repository.mento.MentoProfileRepository;
@@ -104,5 +105,14 @@ public class MentoProfileServiceImpl implements MentoProfileService {
         Double latitude = coordinates[1];  // 위도
 
         mentoProfile.update(requestDto, newImageUrl, latitude, longitude);
+    }
+
+    /* 멘토 프로필 조회 */
+    @Override
+    public MentoProfileResponse getMentoProfile(Long memberSeq) {
+        MentoProfile mentoProfile = mentoProfileRepository.findByMember_MemberSeq(memberSeq)
+                .orElseThrow(() -> new MentoProfileException(CANNOT_FOUND_MENTO_PROFILE));
+
+        return new MentoProfileResponse(mentoProfile);
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- 기존 멘토 프로필 관련 API에서 생성, 수정은 있으나 조회가 빠졌던 부분 추가

## 🔑 변경 사항 (Key Changes)

- MentoController, MentoProfileService, MentoProfileServiceImpl에 조회 메서드 추가
- CreateMentoProfileRequest DTO에 availableDays 중복 삽입 발견 -> MentoDetail로 변경
- MentoProfileResponse DTO 추가

## 📝 리뷰 요구사항 (To Reviewers)

- 로그인한 Mento User의 토큰이 제대로 발급되었는가.
- Postman으로 get 요청 시 알맞게 데이터가 조회되는가.
- 더미데이터 삽입

```
-- 1. 카테고리, 멘토 멤버 생성
INSERT INTO category (category_seq, category_name, category_description, status, created_at, modified_at)
VALUES (1, 'IT/개발', '설명', 'ACTIVE', NOW(), NOW());

INSERT INTO member (member_seq, member_id, member_pwd, member_name, member_phone_number, member_type, member_birth_date, status, created_at, modified_at) VALUES
(1, 'mentor_user', '$2a$10$JTpr8ndyKEiSnAbsM2t33.Jw9GM8uPPG61ip5VGRCiPo0/YJtkFL2', '김멘토', '010-1111-1111', 'MENTO', '1990-01-01', 'ACTIVE', NOW(), NOW())

-- 2. 멘토(1)의 프로필 생성
INSERT INTO mento_profile (mento_profile_content, mento_profile_image, start_time, end_time, available_days, mento_postcode, mento_road_address, mento_bname, mento_detail, latitude, longitude, status, member_seq, created_at, modified_at)
VALUES (
    '김멘토의 프로필입니다.',
    'https://s3.example.com/mentor_profile.jpg',
    '09:00:00',
    '18:00:00',
    '월,수,금',
    '06134',
    '서울 강남구 테헤란로 212',
    '역삼동',
    '멀티캠퍼스 12층',
    37.5012,   
    127.0396,  
    'ACTIVE',
    1,
    NOW(),
    NOW()
);
```

## 확인 방법 
1. postman을 열고 Authorization - Bearer Token에 기존 로그인한 memberSeq 1의 AT 값을 넣는다.
2. 해당 아래 주소로 Get 요청을 보낸다.
```
http://localhost:9999/api/mento/mento-profiles
```
3. 결과가 알맞게 나왔는지 확인한다. (이미지 참조)

<img width="1472" height="701" alt="image" src="https://github.com/user-attachments/assets/9f389b48-7961-48ba-94ec-f7ab2b862258" />
