### PR TITLE
fix: 환불하기 paymentSeq을  reservationSeq로 수정

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/PaymentController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/PaymentController.java
@@ -73,12 +73,12 @@ public class PaymentController {
     /**
      * 환불하기
      */
-    @PostMapping("/mentos/refund/{paymentSeq}")
+    @PostMapping("/mentos/refund/{reservationSeq}")
     public BaseResponse<Void> refund(
                     @CurrentUser Member member,
-                    @PathVariable Long paymentSeq) {
+                    @PathVariable Long reservationSeq) {
         Long currentMemberSeq = member.getMemberSeq();
-        paymentService.refundFull(currentMemberSeq, paymentSeq, "USER_REQUEST");
+        paymentService.refundFull(currentMemberSeq, reservationSeq, "USER_REQUEST");
         return new BaseResponse<>(SUCCESS, null);
 
    }

--- a/src/main/java/com/shinhanDS5gi/memento/repository/PaymentRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/PaymentRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
@@ -18,4 +20,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     int updatePaymentStatus(@Param("memberSeq") Long memberSeq,
                             @Param("afterStatus") BaseStatus afterStatus,
                             @Param("beforeStatus") BaseStatus beforeStatus);
+
+    Optional<Payment> findByReservation_ReservationSeqAndMember_MemberSeqAndStatus(
+            Long reservationSeq, Long memberSeq, BaseStatus status);
+
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/PaymentService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/PaymentService.java
@@ -20,6 +20,6 @@ public interface PaymentService {
     void fail(String code, String message, String orderId);
 
     /* 환불하기 */
-    void refundFull(Long currentMemberSeq, Long paymentSeq, String reason);
+    void refundFull(Long currentMemberSeq, Long reservationSeq, String reason);
 }
 

--- a/src/main/java/com/shinhanDS5gi/memento/service/PaymentServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/PaymentServiceImpl.java
@@ -177,10 +177,14 @@ public class PaymentServiceImpl implements PaymentService {
         throw new PaymentException(PAYMENT_FAILED, "결제에 실패했습니다: " + message);
     }
 
+    //환불하기
     @Override
     @Transactional
-    public void refundFull(Long currentMemberSeq, Long paymentSeq, String reason) {
-        Payment payment = paymentRepository.findById(paymentSeq)
+    public void refundFull(Long currentMemberSeq, Long reservationSeq, String reason) {
+        Payment payment = paymentRepository
+                .findByReservation_ReservationSeqAndMember_MemberSeqAndStatus(
+                        reservationSeq, currentMemberSeq, BaseStatus.ACTIVE
+                )
                 .orElseThrow(() -> new PaymentException(PAYMENT_NOT_FOUND, "환불할 결제 정보를 찾을 수 없습니다."));
 
         // (핵심 보안 검증) 해당 결제의 소유주가 환불을 요청한 사용자가 맞는지 반드시 확인


### PR DESCRIPTION
## 요약 (Summary)
- 환불하기 paymentSeq을  reservationSeq로 수정
-paymentSeq를 주는곳이 없어서 

## 🔑 변경 사항 (Key Changes)
- PaymentContoller
- PaymentService
- PaymentServiceImpl
- PaymentRepository

## 확인 방법 
- 먼저 postman으로 로그인 한다 
- POST로 menti 로그인 후 AccessToken을 얻는다  
- 예약하기->redis에서 예약자 찾기 -> 결제하기를 하고 
- 그 후 POST 요청으로 Authorization에 AT를 넣고 보낸다
```
http://localhost:9999/api/mentos/refund/{reservationSeq}

```
<img width="1854" height="894" alt="image" src="https://github.com/user-attachments/assets/d2a474a2-18c0-4f30-9998-43347ddcc69c" />
<img width="967" height="119" alt="image" src="https://github.com/user-attachments/assets/21b27d63-e85e-4c26-bd55-a3bc905a6e52" />
