### PR TITLE
feat: 멘토스 상세보기 리뷰 무한스크롤로 불러오기

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -6,6 +6,7 @@ import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.dto.mentos.*;
 import com.shinhanDS5gi.memento.security.CurrentUser;
 import com.shinhanDS5gi.memento.service.MentosService;
+import com.shinhanDS5gi.memento.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -24,6 +25,7 @@ import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionRespo
 public class MentosController {
 
     private final MentosService mentosService;
+    private final ReviewService reviewService;
 
     /* 나의 멘토스 목록 조회 (멘토) */
     @GetMapping("/my-list")
@@ -104,5 +106,15 @@ public class MentosController {
                                                                                      @PathVariable("mentosSeq") Long mentosSeq){
         log.info("[MentosController.showMentosDetailForUpdate]");
         return new BaseResponse<>(mentosService.showMentosDetailForUpdate(member, mentosSeq));
+    }
+
+    /* 멘토스 상세보기 리뷰 무한스크롤 */
+    @GetMapping("/detail/{mentosSeq}/reviews")
+    public BaseResponse<GetReviewListForMentosDetailResponse> getReviewListForMentosDetail(
+            @PathVariable("mentosSeq") Long mentosSeq,
+            @RequestParam(value = "limit", defaultValue = "10") Integer limit,
+            @RequestParam(value = "cursor", required = false) Long cursor){
+        log.info("[MentosController.getReviewListForMentosDetail]");
+        return new BaseResponse<>(reviewService.getReviewListForMentosDetail(mentosSeq, limit, cursor));
     }
 }

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetReviewListForMentosDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetReviewListForMentosDetailResponse.java
@@ -1,0 +1,28 @@
+package com.shinhanDS5gi.memento.dto.mentos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetReviewListForMentosDetailResponse {
+
+    /* 멘토스 상세보기에서 리뷰 무한 스크롤로 받아오기 위한 dto */
+
+    private final List<Review> reviews;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Review{
+        private final Long reviewSeq;
+        private final Integer reviewRating;
+        private final String reviewDate;
+        private final String reviewContent;
+    }
+}
+

--- a/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetReviewListForMentosDetailResponse.java
+++ b/src/main/java/com/shinhanDS5gi/memento/dto/mentos/GetReviewListForMentosDetailResponse.java
@@ -14,6 +14,8 @@ public class GetReviewListForMentosDetailResponse {
     /* 멘토스 상세보기에서 리뷰 무한 스크롤로 받아오기 위한 dto */
 
     private final List<Review> reviews;
+    private final boolean hasNext;
+    private final Long nextCursor;
 
     @Getter
     @Builder

--- a/src/main/java/com/shinhanDS5gi/memento/repository/review/ReviewCustomRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/review/ReviewCustomRepository.java
@@ -2,7 +2,7 @@ package com.shinhanDS5gi.memento.repository.review;
 
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.dto.mento.MentoReviewsListResponse;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailResponse;
+import com.shinhanDS5gi.memento.dto.mentos.GetReviewListForMentosDetailResponse;
 
 import java.util.List;
 
@@ -11,5 +11,5 @@ public interface ReviewCustomRepository {
     List<MentoReviewsListResponse> findMentoReviewsByCursor(Long mentoSeq, Long cursor, int limit, BaseStatus status);
 
     /* 멘토스 상세조회 */
-    //List<GetMentosDetailResponse.Review> findReviewByMentosSeqAndStatus(Long mentosSeq, BaseStatus status);
+    List<GetReviewListForMentosDetailResponse.Review> findReviewByMentosSeqAndLimitAndCursorAndStatus(Long mentosSeq, Integer limit, Long cursor, BaseStatus status);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/repository/review/ReviewRepositoryImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/review/ReviewRepositoryImpl.java
@@ -10,9 +10,8 @@ import com.shinhanDS5gi.memento.domain.QReview;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.QMember;
 import com.shinhanDS5gi.memento.dto.mento.MentoReviewsListResponse;
-import com.shinhanDS5gi.memento.dto.mentos.GetMentosDetailResponse;
+import com.shinhanDS5gi.memento.dto.mentos.GetReviewListForMentosDetailResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -57,30 +56,31 @@ public class ReviewRepositoryImpl implements ReviewCustomRepository {
                 .fetch();
     }
 
-    /* 멘토스 상세조회에 쓰이는 review 3개 */
-//    @Override
-//    public List<GetMentosDetailResponse.Review> findReviewByMentosSeqAndStatus(Long mentosSeq, BaseStatus status) {
-//        QReview review = QReview.review;
-//        QReservation reservation = QReservation.reservation;
-//
-//        return queryFactory
-//                .select(Projections.constructor(GetMentosDetailResponse.Review.class,
-//                        review.reviewSeq,
-//                        review.reviewRating,
-//                        // MySQL DATE_FORMAT 그대로 사용
-//                        Expressions.stringTemplate("date_format({0}, {1})",
-//                                review.createdAt, Expressions.constant("%Y-%m-%d")),
-//                        review.reviewContent
-//                ))
-//                .from(review)
-//                .join(review.reservation, reservation)
-//                .where(
-//                        reservation.mentos.mentosSeq.eq(mentosSeq), // ★ mentos 기준 필터
-//                        review.status.eq(status)
-//                )
-//                .orderBy(review.createdAt.desc())
-//                .limit(3)
-//                .fetch();
-//    }
+    /* 멘토스 상세조회에 쓰이는 review  */
+    @Override
+    public List<GetReviewListForMentosDetailResponse.Review> findReviewByMentosSeqAndLimitAndCursorAndStatus(Long mentosSeq, Integer limit, Long cursor, BaseStatus status) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(review.reservation.mentos.mentosSeq.eq(mentosSeq)).and(review.status.eq(status));
+
+        if (cursor != null) {
+            builder.and(review.reviewSeq.lt(cursor));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(GetReviewListForMentosDetailResponse.Review.class,
+                        review.reviewSeq,
+                        review.reviewRating,
+                        // MySQL DATE_FORMAT 그대로 사용
+                        Expressions.stringTemplate("date_format({0}, {1})",
+                                review.createdAt, Expressions.constant("%Y-%m-%d")),
+                        review.reviewContent
+                ))
+                .from(review)
+                .join(review.reservation, reservation)
+                .where(builder)
+                .orderBy(review.reviewSeq.desc())
+                .limit(limit+1)
+                .fetch();
+    }
 
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReviewService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.dto.mento.MentoReviewsListResponse;
 import com.shinhanDS5gi.memento.dto.mento.MentoReviewsSliceResponse;
+import com.shinhanDS5gi.memento.dto.mentos.GetReviewListForMentosDetailResponse;
 import com.shinhanDS5gi.memento.dto.mypage.CreateReviewRequest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,4 +14,7 @@ public interface ReviewService {
     /* 리뷰 작성하기 */
     @Transactional
     void createReview(Long memberSeq, CreateReviewRequest requestDTO, String idemKey);
+
+    /* 리뷰 불러오기 */
+    GetReviewListForMentosDetailResponse getReviewListForMentosDetail(Long mentosSeq, Integer limit, Long cursor);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/ReviewServiceImpl.java
@@ -2,21 +2,15 @@ package com.shinhanDS5gi.memento.service;
 
 import com.shinhanDS5gi.memento.common.exception.ReservationException;
 import com.shinhanDS5gi.memento.common.exception.ReviewException;
-import com.shinhanDS5gi.memento.common.exception.MemberException;
-import com.shinhanDS5gi.memento.common.exception.MentosException;
-import com.shinhanDS5gi.memento.domain.Mentos;
 import com.shinhanDS5gi.memento.domain.Reservation;
 import com.shinhanDS5gi.memento.domain.Review;
 import com.shinhanDS5gi.memento.domain.base.BaseStatus;
-import com.shinhanDS5gi.memento.domain.member.Member;
-//import com.shinhanDS5gi.memento.dto.mypage.CreateReviewRequest;
 import com.shinhanDS5gi.memento.dto.mento.MentoReviewsListResponse;
 import com.shinhanDS5gi.memento.dto.mento.MentoReviewsSliceResponse;
+import com.shinhanDS5gi.memento.dto.mentos.GetReviewListForMentosDetailResponse;
 import com.shinhanDS5gi.memento.dto.mypage.CreateReviewRequest;
-import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
 import com.shinhanDS5gi.memento.repository.ReservationRepository;
 import com.shinhanDS5gi.memento.repository.review.ReviewRepository;
-import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,8 +27,6 @@ import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionRespo
 public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
-    private final MemberRepository memberRepository;
-    private final MentosRepository mentosRepository;
     private final ReservationRepository reservationRepository;
     private final IdempotencyService idempotencyService;
 
@@ -85,5 +77,22 @@ public class ReviewServiceImpl implements ReviewService {
 
         // 멱등키 저장
         idempotencyService.saveKey(idemKey, String.valueOf(savedReview.getReviewSeq()));
+    }
+
+    /* 멘토스 상세보기 리뷰 무한 스크롤 */
+    @Override
+    public GetReviewListForMentosDetailResponse getReviewListForMentosDetail(Long mentosSeq, Integer limit, Long cursor) {
+        log.info("[ReviewServiceImpl.getReviewListForMentosDetail]");
+        List<GetReviewListForMentosDetailResponse.Review> reviewList = reviewRepository.findReviewByMentosSeqAndLimitAndCursorAndStatus(mentosSeq,limit,cursor,BaseStatus.ACTIVE);
+
+        GetReviewListForMentosDetailResponse result;
+
+        if(reviewList.size() <= limit){
+            result = new GetReviewListForMentosDetailResponse(reviewList.stream().limit(limit).toList(),false,null );
+        }else{
+            result = new GetReviewListForMentosDetailResponse(reviewList.stream().limit(limit).toList(), true, reviewList.get(reviewList.size()-1).getReviewSeq()+1);
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
## 요약 (Summary)
- [x] 멘토스 상세보기로 들어가면 리뷰를 무한으로 띄워올 수 있도록 하는 리뷰만 불러오는 api 입니다.

## 🔑 변경 사항 (Key Changes)

- 기존에 3개만 불러오던 리뷰를 원하는 갯수만큼 불러올 수 있도록 쿼리문 수정하였습니다.
- 기존의 무한 스크롤과 동일한 방법으로 구현하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] api 명세서대로 반환되는지 [명세서 바로가기](https://paint-doll-0ba.notion.site/272fa60ecd058090ae99f31aac7090cf?source=copy_link)

## 확인 방법 
```
http://localhost:9999/api/mentos/detail/1/reviews?limit=5
```
postman 으로 위의 주소로 get 요청 보내주세요.
cursor 에는 이전 요청의 nextCursor 를 넣어주시면 됩니다