### PR TITLE
feat: 멘토스 삭제할 때 예약이 존재하면 삭제 안되도록 막기

### DIFF
--- a/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/shinhanDS5gi/memento/common/response/status/BaseExceptionResponseStatus.java
@@ -30,6 +30,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
     NO_REVIEWS_FOUND_FOR_MENTO(2504, HttpStatus.NOT_FOUND.value(), "요청하신 멘토의 멘토스 리뷰는 존재하지 않습니다."),
     CANNOT_CREATE_MENTOS(2505, HttpStatus.BAD_REQUEST.value(), "멘토스를 생성할 수 없습니다."),
     MENTOS_NOT_FOUND(2506,HttpStatus.BAD_REQUEST.value(), "요청하신 멘토스가 없습니다."),
+    CANNOT_DELETE_MENTOS(2507, HttpStatus.CONFLICT.value(), "예약이 존재하여 삭제할 수 없습니다."),
 
     /**
      * Token 관련 3000대

--- a/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
+++ b/src/main/java/com/shinhanDS5gi/memento/controller/MentosController.java
@@ -57,10 +57,11 @@ public class MentosController {
     public BaseResponse<Void> inactiveMentos(
             @CurrentUser Member member,
             @PathVariable("mentosSeq") Long mentosSeq) {
+        log.info("[MentosController.inactiveMentos]");
+
         Long currentMemberSeq = member.getMemberSeq();
         mentosService.inactiveMentos(mentosSeq, currentMemberSeq);
-
-        return new BaseResponse<>(SUCCESS, null);
+        return new BaseResponse<>(null);
     }
 
     /* 멘토스 상세조회 */

--- a/src/main/java/com/shinhanDS5gi/memento/repository/ReservationRepository.java
+++ b/src/main/java/com/shinhanDS5gi/memento/repository/ReservationRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;import com.shinhanDS5gi.memento.domain.base.BaseStatus;
+import java.util.Optional;
+import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import org.springframework.data.jpa.repository.Modifying;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
@@ -62,4 +63,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     boolean existsByMentos_MentosSeqAndMentosAtAndMentosTimeAndStatus(Long mentosSeq, LocalDate mentosAt, LocalTime mentosTime, BaseStatus status);
 
     Optional<Reservation> findByReservationSeqAndStatus(Long reservationSeq, BaseStatus baseStatus);
+
+    boolean existsByMentos_MentosSeqAndStatus(Long mentosSeq, BaseStatus status);
 }

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosService.java
@@ -15,7 +15,7 @@ public interface MentosService {
     void updateMentos(Long mentosSeq, Long currentMemberId, UpdateMentosRequest requestDto, MultipartFile imageFile) throws IOException;
 
     /* 멘토스 게시글 삭제(비활성화)  */
-    void inactiveMentos(Long mentosSeq, Long currentMemberId);
+    void inactiveMentos(Long mentosSeq, Long currentMemberSeq);
 
     /* 멘토스 상세조회 */
     GetMentosDetailResponse getMentosDetail(Long mentosSeq);

--- a/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
+++ b/src/main/java/com/shinhanDS5gi/memento/service/MentosServiceImpl.java
@@ -11,9 +11,9 @@ import com.shinhanDS5gi.memento.domain.base.BaseStatus;
 import com.shinhanDS5gi.memento.domain.member.Member;
 import com.shinhanDS5gi.memento.domain.member.MemberType;
 import com.shinhanDS5gi.memento.dto.mentos.*;
+import com.shinhanDS5gi.memento.repository.ReservationRepository;
 import com.shinhanDS5gi.memento.repository.mento.MentoProfileRepository;
 import com.shinhanDS5gi.memento.repository.CategoryRepository;
-import com.shinhanDS5gi.memento.repository.review.ReviewRepository;
 
 import com.shinhanDS5gi.memento.repository.member.MemberRepository;
 import com.shinhanDS5gi.memento.repository.mentos.MentosRepository;
@@ -31,7 +31,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.shinhanDS5gi.memento.common.response.status.BaseExceptionResponseStatus.*;
-import static com.shinhanDS5gi.memento.domain.QReview.review;
 
 @Slf4j
 @Service
@@ -43,7 +42,7 @@ public class MentosServiceImpl implements MentosService {
     private final MentosRepository mentosRepository;
     private final CategoryRepository categoryRepository;
     private final MentoProfileRepository mentoProfileRepository;
-    private final ReviewRepository reviewRepository;
+    private final ReservationRepository reservationRepository;
 
     private final S3Uploader s3Uploader;
     private final IdempotencyService idempotencyService;
@@ -124,15 +123,18 @@ public class MentosServiceImpl implements MentosService {
     /* 멘토스 삭제하기 */
     @Override
     @Transactional
-    public void inactiveMentos(Long mentosSeq, Long currentMemberId) {
+    public void inactiveMentos(Long mentosSeq, Long currentMemberSeq) {
         // 삭제할 멘토스 DB 조회
         Mentos mentos = mentosRepository.findByMentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE)
                 .orElseThrow(() -> new MentosException(CANNOT_FOUND_MENTOS));
 
         // 삭제 권한 확인
-        if (!Objects.equals(mentos.getMember().getMemberSeq(), currentMemberId)) {
+        if (!Objects.equals(mentos.getMember().getMemberSeq(), currentMemberSeq)) {
             throw new MentosException(NO_AUTHORITY_TO_DELETE);
+        } else if (reservationRepository.existsByMentos_MentosSeqAndStatus(mentosSeq, BaseStatus.ACTIVE)) {
+            throw new MentosException(CANNOT_DELETE_MENTOS);
         }
+
         mentos.inactivate();
     }
 


### PR DESCRIPTION
## 요약 (Summary)
- [x] 기존에는 삭제하려는 멘토스에 대한 예약이 존재하더라도 그냥 삭제하도록 구현되어있었는데, 서비스상 예약이 존재하면 삭제할 수 없도록 막아야할 것 같아서, 예약이 존재한다면 삭제할 수 없도록 막는 작업 수행하였습니다.

## 🔑 변경 사항 (Key Changes)

- `BaseExceptionResponseStatus 에 CANNOT_DELETE_MENTOS 추가` : 프론트로부터 잘못된 값이 들어오는 것도 아니고 서버 에러도 아니고 서비스 로직상 예외를 터트려야하는 상황이기 때문에  HttpStatus.CONFLICT.value() 상태코드 409 반환하도록 구현하였습니다.
- `existsByMentos_MentosSeqAndStatus` : 복잡한 로직 없이 단순 mentos_seq 를 가지고 reservation 테이블에 active 한 데이터가 있는지를 확인하면 되는 문제였기에 (몇건이 있는지는 상관없음) 간단하게 jpa 이용해서 쿼리문 자동생성 되도록 간편하게 구현하였습니다.

## 📝 리뷰 요구사항 (To Reviewers)

- [ ] 지우려는 멘토스에 예약이 존재하면 삭제할 수 없다는 응답이 잘 반환되는지

## 확인 방법 
```
INSERT INTO reservation (member_seq, mentos_seq, mentos_at, mentos_time, created_at, modified_at, status)
VALUES
(32, 1, '2025-09-05', '09:00:00', NOW(6), NULL, 'ACTIVE'),
(33, 1, '2025-09-08', '09:00:00', NOW(6), NULL, 'ACTIVE'),
(32, 1, '2025-09-10', '09:00:00', NOW(6), NULL, 'ACTIVE'),
(31, 1, '2025-09-12', '09:00:00', NOW(6), NULL, 'ACTIVE'),
(30, 1, '2025-09-15', '09:00:00', NOW(6), NULL, 'ACTIVE');
```
위의 쿼리문을 실행시켜 주시고(member 는 노션에 있는 더미데이터가 모두 들어있어야 해당 쿼리문 정상작동합니다.)

postman 에서 아래의 주소로 patch 요청 보내주세요

```
http://localhost:9999/api/mentos/1
```
당연히 헤더에 jwt 토큰 들어있어야 합니다.

<img width="1920" height="1080" alt="스크린샷 2025-09-26 09 56 50" src="https://github.com/user-attachments/assets/eb5a903f-0c35-4fbf-89ea-cb9e70d4ac0a" />

다음과 같이 응답 오는 것을 확인하실 수 있습니다.